### PR TITLE
Version v1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ Whether you're a blockchain enthusiast, developer, or enterprise seeking to harn
 - [ ] Key Management using HSM / Vault
 
 ### Releases
-- [v1.0.1](https://github.com/npci/falcon/releases/latest)
+- [v1.0.2](https://github.com/npci/falcon/releases/latest)
+- [v1.0.1](https://github.com/npci/falcon/releases/tag/v1.0.1)
 - [v1.0.0](https://github.com/npci/falcon/releases/tag/v1.0.0)
+
 
 ### Samples
 Please refer our [examples](examples/README.md) for running a complete blockchain network using the deployment helper.

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,12 +40,11 @@ Clone this repository and change your directory to the root directory. First you
   ```
   helm install filestore -n filestore helm-charts/filestore/ -f examples/filestore/values.yaml --create-namespace
   ```
-  If you have your own domain, image and ingress class. Then update the below mentioned values in the [examples/filestore/values.yaml](./filestore/values.yaml).
-  - image
-  - global.hlf_domain
-  - ingress.className
+  If you have your own HLF domain, then update it under `.Values.global.hlf_domain` in the below mentioned values [examples/filestore/values.yaml](./filestore/values.yaml).
 
-  Once deployed, you will see the resources and an ingress with hostname `filestore.my-hlf-domain.com`. This will be your filestore end point. Exec into any of your running pods in the same cluster and check with a curl request to make sure that everything is working as expected. 
+  Once deployed, you will see the resources and an ingress with hostname `filestore.my-hlf-domain.com`. This will be your filestore end point. Exec into any of your running pods in the same cluster and check with a curl request to make sure that everything is working as expected. If you have your own custom domain/subdomain DNS for the filestore FQDN, then you can use `.Values.hostOverride` to input your own FQDN. Optionally you can add TLS cert to this ingress resource. To do that, you can create a kubenetes secret of tls type and provide it here in `.Values.ingress.tls.secretName`
+
+  ***IMP*** If you're changing the filestore release name/ingress port/host then you will have to update the other values file where it has a reference. 
 
   ```
   curl http://filestore.my-hlf-domain.com:30001
@@ -197,7 +196,7 @@ Once the `Org2` ICA started successfully, you would need to add this `Org2` to t
 ```
 helm upgrade configorgchannel -n initialpeerorg helm-charts/fabric-ops/ -f examples/fabric-ops/initialpeerorg/configure-org-channel.yaml
 ```
-3. **Create Org1 identities with ica-org1.**
+3. **Create Org2 identities with ica-org2.**
 ```
 helm install org2-ca-ops -n org2 helm-charts/fabric-ops/ -f examples/fabric-ops/org2/identities.yaml 
 ```

--- a/examples/fabric-ops/initialpeerorg/approve-chaincode.yaml
+++ b/examples/fabric-ops/initialpeerorg/approve-chaincode.yaml
@@ -30,6 +30,7 @@ csr_names_o: Your Company Name
 
 orderer_endpoint: orderer0-orderer.my-hlf-domain.com:30000
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
+filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
 require_collection_config: "true"
 collection_config_file: "collection-config.json"
 collection_config_file_hash: "627dd1b8d679dc52475c148e502c576b109796df8495282ba602cc51ec173286"

--- a/examples/fabric-ops/initialpeerorg/approve-chaincode.yaml
+++ b/examples/fabric-ops/initialpeerorg/approve-chaincode.yaml
@@ -48,6 +48,12 @@ identities:
     identity_secret: peer0initialpeerorgSamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# Not required for identity registration, but we use the same values file for deploying fabric-tools helm chart. 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-initialpeerorg/msp
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/examples/fabric-ops/initialpeerorg/channel-create.yaml
+++ b/examples/fabric-ops/initialpeerorg/channel-create.yaml
@@ -43,6 +43,11 @@ identities:
     identity_secret: peer0initialpeerorgSamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-initialpeerorg/msp
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/examples/fabric-ops/initialpeerorg/channel-create.yaml
+++ b/examples/fabric-ops/initialpeerorg/channel-create.yaml
@@ -20,6 +20,7 @@ ca:
 
 orderer_endpoint: orderer0-orderer.my-hlf-domain.com:30000
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
+filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
 config_transaction_filename: channel.tx
 channel_block_filename: mychannel.block
 

--- a/examples/fabric-ops/initialpeerorg/commit-chaincode.yaml
+++ b/examples/fabric-ops/initialpeerorg/commit-chaincode.yaml
@@ -31,6 +31,7 @@ csr_names_o: Your Company Name
 
 orderer_endpoint: orderer0-orderer.my-hlf-domain.com:30000
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
+filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
 collection_config_file: collection-config.json
 collection_config_file_hash: "627dd1b8d679dc52475c148e502c576b109796df8495282ba602cc51ec173286"
 

--- a/examples/fabric-ops/initialpeerorg/commit-chaincode.yaml
+++ b/examples/fabric-ops/initialpeerorg/commit-chaincode.yaml
@@ -48,6 +48,12 @@ identities:
     identity_secret: peer0initialpeerorgSamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# Not required for identity registration, but we use the same values file for deploying fabric-tools helm chart. 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-initialpeerorg/msp
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/examples/fabric-ops/initialpeerorg/configure-org-channel.yaml
+++ b/examples/fabric-ops/initialpeerorg/configure-org-channel.yaml
@@ -33,6 +33,11 @@ identities:
     identity_secret: peer0initialpeerorgSamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-initialpeerorg/msp
+
 # Organizations to be added
 organizatons:
  - name: org1

--- a/examples/fabric-ops/initialpeerorg/identities.yaml
+++ b/examples/fabric-ops/initialpeerorg/identities.yaml
@@ -40,6 +40,12 @@ identities:
     identity_secret: peer2initialpeerorgSamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# Not required for identity registration, but we use the same values file for deploying fabric-tools helm chart. 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-initialpeerorg/msp
+
 tools:
   storageAccessMode: ReadWriteOnce
   storageSize: "5Gi"

--- a/examples/fabric-ops/initialpeerorg/install-chaincode.yaml
+++ b/examples/fabric-ops/initialpeerorg/install-chaincode.yaml
@@ -19,6 +19,7 @@ ca:
  tlss_ca_endpoint: tls-ca.my-hlf-domain.com:30000
 
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
+filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
 channel_block_filename: mychannel.block
 retry_seconds: 10
 

--- a/examples/fabric-ops/initialpeerorg/install-chaincode.yaml
+++ b/examples/fabric-ops/initialpeerorg/install-chaincode.yaml
@@ -49,6 +49,11 @@ identities:
     identity_secret: peer2initialpeerorgSamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-initialpeerorg/msp
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/examples/fabric-ops/initialpeerorg/update-anchor-peer.yaml
+++ b/examples/fabric-ops/initialpeerorg/update-anchor-peer.yaml
@@ -40,6 +40,11 @@ identities:
     identity_secret: peer0initialpeerorgSamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-initialpeerorg/msp
+
 anchor_peers:
    - host: peer0-initialpeerorg.my-hlf-domain.com
      port: "30000"

--- a/examples/fabric-ops/orderer/orderer-cryptogen.yaml
+++ b/examples/fabric-ops/orderer/orderer-cryptogen.yaml
@@ -47,6 +47,7 @@ config_transaction_filename: channel.tx
 
 hlf_channel: "mychannel"
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
+filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
 
 anchorPeers:
    - host: peer0-initialpeerorg.my-hlf-domain.com

--- a/examples/fabric-ops/org1/approve-chaincode.yaml
+++ b/examples/fabric-ops/org1/approve-chaincode.yaml
@@ -30,6 +30,7 @@ csr_names_o: Your Company Name
 
 orderer_endpoint: orderer0-orderer.my-hlf-domain.com:30000
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
+filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
 require_collection_config: "true"
 collection_config_file: "collection-config.json"
 collection_config_file_hash: "627dd1b8d679dc52475c148e502c576b109796df8495282ba602cc51ec173286"

--- a/examples/fabric-ops/org1/approve-chaincode.yaml
+++ b/examples/fabric-ops/org1/approve-chaincode.yaml
@@ -48,6 +48,12 @@ identities:
     identity_secret: peer0org1SamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# Not required for identity registration, but we use the same values file for deploying fabric-tools helm chart. 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-org1/msp
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/examples/fabric-ops/org1/identities.yaml
+++ b/examples/fabric-ops/org1/identities.yaml
@@ -40,6 +40,12 @@ identities:
     identity_secret: peer2org1SamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# Not required for identity registration, but we use the same values file for deploying fabric-tools helm chart. 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-org1/msp
+
 tools:
   storageAccessMode: ReadWriteOnce
   storageSize: "5Gi"

--- a/examples/fabric-ops/org1/install-chaincode.yaml
+++ b/examples/fabric-ops/org1/install-chaincode.yaml
@@ -49,6 +49,12 @@ identities:
     identity_secret: peer2org1SamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# Not required for identity registration, but we use the same values file for deploying fabric-tools helm chart. 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-org1/msp
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/examples/fabric-ops/org1/install-chaincode.yaml
+++ b/examples/fabric-ops/org1/install-chaincode.yaml
@@ -24,6 +24,7 @@ ca:
  tlss_ca_endpoint: tls-ca.my-hlf-domain.com:30000
 
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
+filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
 channel_block_filename: mychannel.block
 retry_seconds: 10
 

--- a/examples/fabric-ops/org1/update-anchor-peer.yaml
+++ b/examples/fabric-ops/org1/update-anchor-peer.yaml
@@ -40,6 +40,12 @@ identities:
     identity_secret: peer0org1SamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# Not required for identity registration, but we use the same values file for deploying fabric-tools helm chart. 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-org1/msp
+
 anchor_peers:
    - host: peer0-org1.my-hlf-domain.com
      port: "30000"

--- a/examples/fabric-ops/org2/approve-chaincode.yaml
+++ b/examples/fabric-ops/org2/approve-chaincode.yaml
@@ -30,6 +30,7 @@ csr_names_o: Your Company Name
 
 orderer_endpoint: orderer0-orderer.my-hlf-domain.com:30000
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
+filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
 require_collection_config: "true"
 collection_config_file: "collection-config.json"
 collection_config_file_hash: "627dd1b8d679dc52475c148e502c576b109796df8495282ba602cc51ec173286"

--- a/examples/fabric-ops/org2/approve-chaincode.yaml
+++ b/examples/fabric-ops/org2/approve-chaincode.yaml
@@ -48,6 +48,11 @@ identities:
     identity_secret: peer0org2SamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# Not required for identity registration, but we use the same values file for deploying fabric-tools helm chart. 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-org2/msp
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/examples/fabric-ops/org2/identities.yaml
+++ b/examples/fabric-ops/org2/identities.yaml
@@ -37,6 +37,12 @@ identities:
     identity_secret: peer1org2SamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# Not required for identity registration, but we use the same values file for deploying fabric-tools helm chart. 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-org2/msp
+
 tools:
   storageAccessMode: ReadWriteOnce
   storageSize: "5Gi"

--- a/examples/fabric-ops/org2/install-chaincode.yaml
+++ b/examples/fabric-ops/org2/install-chaincode.yaml
@@ -19,6 +19,7 @@ ca:
  tlss_ca_endpoint: tls-ca.my-hlf-domain.com:30000
 
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
+filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
 channel_block_filename: mychannel.block
 retry_seconds: 10
 

--- a/examples/fabric-ops/org2/install-chaincode.yaml
+++ b/examples/fabric-ops/org2/install-chaincode.yaml
@@ -46,6 +46,11 @@ identities:
     identity_secret: peer1org2SamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# Not required for identity registration, but we use the same values file for deploying fabric-tools helm chart. 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-org2/msp
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/examples/fabric-ops/org2/update-anchor-peer.yaml
+++ b/examples/fabric-ops/org2/update-anchor-peer.yaml
@@ -40,6 +40,12 @@ identities:
     identity_secret: peer0org2SamplePassword
     identity_type: peer
 
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# Not required for identity registration, but we use the same values file for deploying fabric-tools helm chart. 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-org2/msp
+
 anchor_peers:
    - host: peer0-org2.my-hlf-domain.com
      port: "30000"

--- a/examples/fabric-orderer/orderer.yaml
+++ b/examples/fabric-orderer/orderer.yaml
@@ -25,6 +25,9 @@ csr_names_o: Your Company Name
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
 filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
 block_file: genesis.block
+ica_tls_cert_file: /root/cert.pem
+enroll_on_every_pod_recreation: true
+retry_seconds: 60
 
 hlf_domain: my-hlf-domain.com
 ca:
@@ -35,10 +38,6 @@ init:
   image:
    repository: npcioss/hlf-builder
    tag: 2.4
-
-ica_tls_cert_file: /root/cert.pem
-enroll_on_every_pod_recreation: true
-retry_seconds: 60
 
 global:
   containerPort: 7050

--- a/examples/fabric-orderer/orderer.yaml
+++ b/examples/fabric-orderer/orderer.yaml
@@ -23,6 +23,7 @@ csr_names_l: Mumbai
 csr_names_o: Your Company Name
 
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
+filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
 block_file: genesis.block
 
 hlf_domain: my-hlf-domain.com
@@ -36,6 +37,7 @@ init:
    tag: 2.4
 
 ica_tls_cert_file: /root/cert.pem
+enroll_on_every_pod_recreation: true
 retry_seconds: 60
 
 global:
@@ -54,7 +56,8 @@ global:
     annotations:
       nginx.ingress.kubernetes.io/ssl-passthrough: "true"
   storageAccessMode: ReadWriteOnce
-  storageSize: "10Gi"
+  dataStorageSize: "10Gi"
+  certStorageSize: "50M"
   storageClass: standard
   env:
     - name: FABRIC_LOGGING_SPEC

--- a/examples/fabric-peer/initialpeerorg/values.yaml
+++ b/examples/fabric-peer/initialpeerorg/values.yaml
@@ -22,6 +22,7 @@ ica_tls_cert_file: /root/ica-cert.pem
 tlsca_tls_cert_file: /root/tlsca-cert.pem
 fabric_base_dir: /etc/hyperledger/fabric
 enroll_on_every_pod_recreation: true
+renew_peer_certs: false
 retry_seconds: 60
 
 peers:

--- a/examples/fabric-peer/initialpeerorg/values.yaml
+++ b/examples/fabric-peer/initialpeerorg/values.yaml
@@ -21,6 +21,7 @@ init:
 ica_tls_cert_file: /root/ica-cert.pem
 tlsca_tls_cert_file: /root/tlsca-cert.pem
 fabric_base_dir: /etc/hyperledger/fabric
+enroll_on_every_pod_recreation: true
 retry_seconds: 60
 
 peers:
@@ -85,6 +86,7 @@ global:
   peerServiceType: ClusterIP
   peerServicePort: "30002"
   peerDiskSize: 1G
+  peerCertDiskSize: 50M
   peerPvcAccessMode: ReadWriteOnce
   peerArgs:
     - peer

--- a/examples/fabric-peer/org1/values.yaml
+++ b/examples/fabric-peer/org1/values.yaml
@@ -21,6 +21,7 @@ init:
 ica_tls_cert_file: /root/ica-cert.pem
 tlsca_tls_cert_file: /root/tlsca-cert.pem
 fabric_base_dir: /etc/hyperledger/fabric
+enroll_on_every_pod_recreation: true
 retry_seconds: 60
 
 peers:
@@ -85,6 +86,7 @@ global:
   peerServiceType: ClusterIP
   peerServicePort: "30002"
   peerDiskSize: 1G
+  peerCertDiskSize: 50M
   peerPvcAccessMode: ReadWriteOnce
   peerSecurityContext: {}
   peerArgs:

--- a/examples/fabric-peer/org1/values.yaml
+++ b/examples/fabric-peer/org1/values.yaml
@@ -22,6 +22,7 @@ ica_tls_cert_file: /root/ica-cert.pem
 tlsca_tls_cert_file: /root/tlsca-cert.pem
 fabric_base_dir: /etc/hyperledger/fabric
 enroll_on_every_pod_recreation: true
+renew_peer_certs: false
 retry_seconds: 60
 
 peers:

--- a/examples/fabric-peer/org2/values.yaml
+++ b/examples/fabric-peer/org2/values.yaml
@@ -21,6 +21,7 @@ init:
 ica_tls_cert_file: /root/ica-cert.pem
 tlsca_tls_cert_file: /root/tlsca-cert.pem
 fabric_base_dir: /etc/hyperledger/fabric
+enroll_on_every_pod_recreation: true
 retry_seconds: 60
 
 peers:
@@ -82,6 +83,7 @@ global:
   peerServiceType: ClusterIP
   peerServicePort: "30002"
   peerDiskSize: 1G
+  peerCertDiskSize: 50M
   peerPvcAccessMode: ReadWriteOnce
   peerSecurityContext: {}
   peerArgs:

--- a/examples/fabric-peer/org2/values.yaml
+++ b/examples/fabric-peer/org2/values.yaml
@@ -22,6 +22,7 @@ ica_tls_cert_file: /root/ica-cert.pem
 tlsca_tls_cert_file: /root/tlsca-cert.pem
 fabric_base_dir: /etc/hyperledger/fabric
 enroll_on_every_pod_recreation: true
+renew_peer_certs: false
 retry_seconds: 60
 
 peers:

--- a/examples/filestore/values.yaml
+++ b/examples/filestore/values.yaml
@@ -37,6 +37,14 @@ service:
   type: ClusterIP
   port: 80
 
+# You need to add a resolvable DNS entry here. An ingress resource will be created based on this domain. 
+# Eg; domain.com, then the ingress will be created "filestore.domain.com"
+global:
+ hlf_domain: "my-hlf-domain.com"
+
+# If you want to override the global.hlf_domain FQDN and use your own FQDN, then use this .Values.hostOverride
+# hostOverride: "custom.filestore.com" 
+
 ingress:
   enabled: true
   className: "nginx"
@@ -45,6 +53,8 @@ ingress:
     - paths:
         - path: /
           pathType: Prefix
+  # tls:
+  #  secretName: my-hlf-domain-ssl-certs
 
 resources: {}
   # limits:
@@ -54,16 +64,10 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-# You need to add a resolvable DNS entry here. An ingress resource will be created based ont this domain. 
-# Eg; domain.com, then the ingress will be created "filestore.domain.com"
-global:
- hlf_domain: "my-hlf-domain.com"
-
 storage:
  size: 1G
  accessMode: ReadWriteOnce
  storageClass: standard
-
 
 autoscaling:
   enabled: false

--- a/helm-charts/fabric-ca/Chart.yaml
+++ b/helm-charts/fabric-ca/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: fabric-ca
 description: A Helm chart for deploying Fabric CA Server in Kubernetes.
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "1.5.0"

--- a/helm-charts/fabric-ops/Chart.yaml
+++ b/helm-charts/fabric-ops/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: fabric-ops
 description: A Helm chart for performing various Fabric CA Server operations Kubernetes.
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "1.5.0"

--- a/helm-charts/fabric-ops/templates/cm-chaincode-ops.yaml
+++ b/helm-charts/fabric-ops/templates/cm-chaincode-ops.yaml
@@ -174,11 +174,11 @@ data:
             echo "--------------------------------------------------------------------"
             echo "Atempting to download $file_name from $filestore_download_url"
             echo "--------------------------------------------------------------------"
-            if curl --silent --head --fail "$filestore_download_url"; then
+            if curl --silent --head --fail $filestore_download_url {{- if .Values.filestore_ssl  }} --insecure {{- end }}; then
               echo "--------------------------------------------------------------------"
               echo "Received success http response, downloading $file_name from $filestore_download_url"
               echo "--------------------------------------------------------------------"
-              curl $filestore_download_url -o $file_name
+              curl $filestore_download_url -o $file_name {{- if .Values.filestore_ssl  }} --insecure {{- end }}
               echo "Received file SHA256 value is = $(sha256sum $file_name)"
               break;
             else
@@ -198,7 +198,7 @@ data:
       echo "============================ Creating channel ============================"
       peer channel create -o {{ .Values.orderer_endpoint }} -c {{ $ChannelName }} -f {{ $.Values.workdir }}/peer/{{ .Values.config_transaction_filename }} --tls true --cafile $ORDERER_CA --connTimeout 30s
       echo "============================ Uploading {{ .Values.channel_block_filename }} to Filestore at {{ .Values.filestore_endpoint }} ============================"
-      curl -T {{ .Values.channel_block_filename }} {{ .Values.filestore_endpoint }}/{{ $Project }}/
+      curl -T {{ .Values.channel_block_filename }} {{ .Values.filestore_endpoint }}/{{ $Project }}/ {{- if .Values.filestore_ssl  }} --insecure {{- end }}
       if [ $? -ne 0 ]; then
         echo "========================================= [ERROR] =============================================="
         echo "[ERROR]::One of the previous step returned an error, please debug it manually using cli pod and re-run this job if necessary"
@@ -224,11 +224,11 @@ data:
             echo "--------------------------------------------------------------------"
             echo "Atempting to download $file_name from $filestore_download_url"
             echo "--------------------------------------------------------------------"
-            if curl --silent --head --fail "$filestore_download_url"; then
+            if curl --silent --head --fail "$filestore_download_url" {{- if .Values.filestore_ssl  }} --insecure {{- end }}; then
               echo "--------------------------------------------------------------------"
               echo "Received success http response, downloading $file_name from $filestore_download_url"
               echo "--------------------------------------------------------------------"
-              curl $filestore_download_url -o $file_name
+              curl $filestore_download_url -o $file_name {{- if .Values.filestore_ssl  }} --insecure {{- end }}
               echo "Received file SHA256 value is = $(sha256sum $file_name)"
               break;
             else
@@ -281,11 +281,11 @@ data:
             echo "--------------------------------------------------------------------"
             echo "Atempting to download $file_name from $filestore_download_url"
             echo "--------------------------------------------------------------------"
-            if curl --silent --head --fail "$filestore_download_url"; then
+            if curl --silent --head --fail "$filestore_download_url" {{- if .Values.filestore_ssl  }} --insecure {{- end }}; then
               echo "--------------------------------------------------------------------"
               echo "Received success http response, downloading $file_name from $filestore_download_url"
               echo "--------------------------------------------------------------------"
-              curl $filestore_download_url -o $file_name
+              curl $filestore_download_url -o $file_name {{- if .Values.filestore_ssl  }} --insecure {{- end }}
               echo "Received file SHA256 value is = $(sha256sum $file_name)"
               break;
             else
@@ -490,11 +490,11 @@ data:
             echo "--------------------------------------------------------------------"
             echo "Atempting to download $file_name from $filestore_download_url"
             echo "--------------------------------------------------------------------"
-            if curl --silent --head --fail "$filestore_download_url"; then
+            if curl --silent --head --fail "$filestore_download_url" {{- if .Values.filestore_ssl  }} --insecure {{- end }}; then
               echo "--------------------------------------------------------------------"
               echo "Received success http response, downloading $file_name from $filestore_download_url"
               echo "--------------------------------------------------------------------"
-              curl $filestore_download_url -o $file_name
+              curl $filestore_download_url -o $file_name {{- if .Values.filestore_ssl  }} --insecure {{- end }}
               echo "Received file SHA256 value is = $(sha256sum $file_name)"
               break;
             else

--- a/helm-charts/fabric-ops/templates/cryptogen-cm.yaml
+++ b/helm-charts/fabric-ops/templates/cryptogen-cm.yaml
@@ -139,7 +139,7 @@ data:
         echo "--------------------------------------------------------------------"
         echo "Uploading $FABRIC_IDENTITY tls cert file {{ $BaseDir }}/ordererOrganizations/$FABRIC_IDENTITY/tls.tar.gz to filestore {{ .Values.filestore_endpoint }}"
         echo "--------------------------------------------------------------------"
-        curl -T {{ $BaseDir }}/ordererOrganizations/$FABRIC_IDENTITY/tls.tar.gz {{ .Values.filestore_endpoint }}/{{ $Project }}/$FABRIC_IDENTITY-tls-certs.tar.gz
+        curl -T {{ $BaseDir }}/ordererOrganizations/$FABRIC_IDENTITY/tls.tar.gz {{ .Values.filestore_endpoint }}/{{ $Project }}/$FABRIC_IDENTITY-tls-certs.tar.gz {{- if .Values.filestore_ssl  }} --insecure {{- end }}
         if [ $? -eq 0 ]; then
             echo "Successfully uploaded $FABRIC_IDENTITY TLS cert file to filestore."
             sha256sum {{ $BaseDir }}/ordererOrganizations/$FABRIC_IDENTITY/tls.tar.gz
@@ -218,7 +218,7 @@ data:
      echo "--------------------------------"
      echo "Uploading {{ .Values.block_file }} to filestore {{ .Values.filestore_endpoint }}"
      echo "--------------------------------------------------------------------"
-     curl -T {{ .Values.channel_artifact_dir }}/{{ .Values.block_file }} {{ .Values.filestore_endpoint }}/{{ $Project }}/
+     curl -T {{ .Values.channel_artifact_dir }}/{{ .Values.block_file }} {{ .Values.filestore_endpoint }}/{{ $Project }}/ {{- if .Values.filestore_ssl  }} --insecure {{- end }}
       if [ $? -ne 0 ]; then
         echo "[ERROR]::Filestore upload failed, please re-run this job if necessary."
         echo "========================== [ERROR] ================================="
@@ -229,7 +229,7 @@ data:
      echo "--------------------------------------------------------------------"
      echo "Uploading {{ .Values.config_transaction_filename }} to filestore {{ .Values.filestore_endpoint }}"
      echo "--------------------------------------------------------------------"
-     curl -T {{ .Values.channel_artifact_dir }}/{{ .Values.config_transaction_filename }} {{ .Values.filestore_endpoint }}/{{ $Project }}/
+     curl -T {{ .Values.channel_artifact_dir }}/{{ .Values.config_transaction_filename }} {{ .Values.filestore_endpoint }}/{{ $Project }}/ {{- if .Values.filestore_ssl  }} --insecure {{- end }}
       if [ $? -ne 0 ]; then        
         echo "[ERROR]::Filestore upload failed, please re-run this job if necessary."
         echo "========================== [ERROR] ================================="

--- a/helm-charts/fabric-ops/templates/job-approve-chaincode.yaml
+++ b/helm-charts/fabric-ops/templates/job-approve-chaincode.yaml
@@ -6,9 +6,10 @@ SPDX-License-Identifier:  GPL-3.0
 {{- if eq "chaincode_ops" .Values.job_type }}
 {{- if .Values.fabric_actions.approve_chaincode | default false }}
 
-{{ $BankName    := .Values.nameOverride }}
-{{ $HlfDomain   := .Values.hlf_domain }}
-{{ $ChannelName := .Values.channel_name }}
+{{ $BankName               := .Values.nameOverride }}
+{{ $HlfDomain              := .Values.hlf_domain }}
+{{ $ChannelName            := .Values.channel_name }}
+{{ $CorePeerMspConfigPath  := printf "%s%s" .Values.workdir "/peer/crypto/users/admin/msp" }}
 
 {{- range .Values.identities }}
 {{- if eq "peer" .identity_type }}
@@ -62,7 +63,7 @@ spec:
             - name: CORE_PEER_LOCALMSPID
               value: {{ $BankName }}
             - name: CORE_PEER_MSPCONFIGPATH
-              value: {{ $.Values.workdir }}/peer/crypto/users/admin/msp
+              value: {{ $.Values.core_peer_mspconfigpath_override | default $CorePeerMspConfigPath }}
             - name: CORE_PEER_TLS_CERT_FILE
               value: {{ $.Values.workdir }}/peer/crypto/users/{{ .identity_name }}/tls/server.crt
             - name: CORE_PEER_TLS_ENABLED

--- a/helm-charts/fabric-ops/templates/job-channel-create.yaml
+++ b/helm-charts/fabric-ops/templates/job-channel-create.yaml
@@ -6,9 +6,10 @@ SPDX-License-Identifier:  GPL-3.0
 {{- if eq "chaincode_ops" .Values.job_type }}
 {{- if .Values.fabric_actions.create_channel | default false }}
 
-{{ $BankName    := .Values.nameOverride }}
-{{ $HlfDomain   := .Values.hlf_domain }}
-{{ $ChannelName := .Values.channel_name }}
+{{ $BankName               := .Values.nameOverride }}
+{{ $HlfDomain              := .Values.hlf_domain }}
+{{ $ChannelName            := .Values.channel_name }}
+{{ $CorePeerMspConfigPath  := printf "%s%s" .Values.workdir "/peer/crypto/users/admin/msp" }}
 
 {{- range .Values.identities }}
 {{- if eq "peer" .identity_type }}
@@ -62,7 +63,7 @@ spec:
             - name: CORE_PEER_LOCALMSPID
               value: {{ $BankName }}
             - name: CORE_PEER_MSPCONFIGPATH
-              value: {{ $.Values.workdir }}/peer/crypto/users/admin/msp
+              value: {{ $.Values.core_peer_mspconfigpath_override | default $CorePeerMspConfigPath }}
             - name: CORE_PEER_TLS_CERT_FILE
               value: {{ $.Values.workdir }}/peer/crypto/users/{{ .identity_name }}/tls/server.crt
             - name: CORE_PEER_TLS_ENABLED

--- a/helm-charts/fabric-ops/templates/job-commit-chaincode.yaml
+++ b/helm-charts/fabric-ops/templates/job-commit-chaincode.yaml
@@ -6,9 +6,10 @@ SPDX-License-Identifier:  GPL-3.0
 {{- if eq "chaincode_ops" .Values.job_type }}
 {{- if .Values.fabric_actions.commit_chaincode | default false }}
 
-{{ $BankName    := .Values.nameOverride }}
-{{ $HlfDomain   := .Values.hlf_domain }}
-{{ $ChannelName := .Values.channel_name }}
+{{ $BankName               := .Values.nameOverride }}
+{{ $HlfDomain              := .Values.hlf_domain }}
+{{ $ChannelName            := .Values.channel_name }}
+{{ $CorePeerMspConfigPath  := printf "%s%s" .Values.workdir "/peer/crypto/users/admin/msp" }}
 
 {{- range .Values.identities }}
 {{- if eq "peer" .identity_type }}
@@ -62,7 +63,7 @@ spec:
             - name: CORE_PEER_LOCALMSPID
               value: {{ $BankName }}
             - name: CORE_PEER_MSPCONFIGPATH
-              value: {{ $.Values.workdir }}/peer/crypto/users/admin/msp
+              value: {{ $.Values.core_peer_mspconfigpath_override | default $CorePeerMspConfigPath }}
             - name: CORE_PEER_TLS_CERT_FILE
               value: {{ $.Values.workdir }}/peer/crypto/users/{{ .identity_name }}/tls/server.crt
             - name: CORE_PEER_TLS_ENABLED

--- a/helm-charts/fabric-ops/templates/job-configure-org-channel.yaml
+++ b/helm-charts/fabric-ops/templates/job-configure-org-channel.yaml
@@ -6,9 +6,10 @@ SPDX-License-Identifier:  GPL-3.0
 {{- if eq "chaincode_ops" .Values.job_type }}
 {{- if .Values.fabric_actions.configure_org_channel }}
 
-{{ $BankName    := .Values.nameOverride }}
-{{ $HlfDomain   := .Values.hlf_domain }}
-{{ $ChannelName := .Values.channel_name }}
+{{ $BankName               := .Values.nameOverride }}
+{{ $HlfDomain              := .Values.hlf_domain }}
+{{ $ChannelName            := .Values.channel_name }}
+{{ $CorePeerMspConfigPath  := printf "%s%s" .Values.workdir "/peer/crypto/users/admin/msp" }}
 
 {{- range .Values.organizatons }}
 ---
@@ -61,7 +62,7 @@ spec:
             - name: CORE_PEER_LOCALMSPID
               value: {{ $BankName }}
             - name: CORE_PEER_MSPCONFIGPATH
-              value: {{ $.Values.workdir }}/peer/crypto/users/admin/msp
+              value: {{ $.Values.core_peer_mspconfigpath_override | default $CorePeerMspConfigPath }}
             - name: CORE_PEER_TLS_CERT_FILE
               value: {{ $.Values.workdir }}/peer/crypto/users/peer0-{{ $BankName }}/tls/server.crt
             - name: CORE_PEER_TLS_ENABLED

--- a/helm-charts/fabric-ops/templates/job-install-chaincode.yaml
+++ b/helm-charts/fabric-ops/templates/job-install-chaincode.yaml
@@ -6,9 +6,10 @@ SPDX-License-Identifier:  GPL-3.0
 {{- if eq "chaincode_ops" .Values.job_type }}
 {{- if .Values.fabric_actions.install_chaincode }}
 
-{{ $BankName    := .Values.nameOverride }}
-{{ $HlfDomain   := .Values.hlf_domain }}
-{{ $ChannelName := .Values.channel_name }}
+{{ $BankName               := .Values.nameOverride }}
+{{ $HlfDomain              := .Values.hlf_domain }}
+{{ $ChannelName            := .Values.channel_name }}
+{{ $CorePeerMspConfigPath  := printf "%s%s" .Values.workdir "/peer/crypto/users/admin/msp" }}
 
 {{- range .Values.identities }}
 {{- if eq "peer" .identity_type }}
@@ -62,7 +63,7 @@ spec:
             - name: CORE_PEER_LOCALMSPID
               value: {{ $BankName }}
             - name: CORE_PEER_MSPCONFIGPATH
-              value: {{ $.Values.workdir }}/peer/crypto/users/admin/msp
+              value: {{ $.Values.core_peer_mspconfigpath_override | default $CorePeerMspConfigPath }}
             - name: CORE_PEER_TLS_CERT_FILE
               value: {{ $.Values.workdir }}/peer/crypto/users/{{ .identity_name }}/tls/server.crt
             - name: CORE_PEER_TLS_ENABLED

--- a/helm-charts/fabric-ops/templates/job-update-anchor-peer.yaml
+++ b/helm-charts/fabric-ops/templates/job-update-anchor-peer.yaml
@@ -6,9 +6,10 @@ SPDX-License-Identifier:  GPL-3.0
 {{- if eq "chaincode_ops" .Values.job_type }}
 {{- if .Values.fabric_actions.update_anchor_peer }}
 
-{{ $BankName     := .Values.nameOverride }}
-{{ $HlfDomain    := .Values.hlf_domain }}
-{{ $ChannelName  := .Values.channel_name }}
+{{ $BankName               := .Values.nameOverride }}
+{{ $HlfDomain              := .Values.hlf_domain }}
+{{ $ChannelName            := .Values.channel_name }}
+{{ $CorePeerMspConfigPath  := printf "%s%s" .Values.workdir "/peer/crypto/users/admin/msp" }}
 
 {{- range .Values.identities }}
 {{- if eq "peer" .identity_type }}
@@ -62,7 +63,7 @@ spec:
             - name: CORE_PEER_LOCALMSPID
               value: {{ $BankName }}
             - name: CORE_PEER_MSPCONFIGPATH
-              value: {{ $.Values.workdir }}/peer/crypto/users/admin/msp
+              value: {{ $.Values.core_peer_mspconfigpath_override | default $CorePeerMspConfigPath }}
             - name: CORE_PEER_TLS_CERT_FILE
               value: {{ $.Values.workdir }}/peer/crypto/users/{{ .identity_name }}/tls/server.crt
             - name: CORE_PEER_TLS_ENABLED

--- a/helm-charts/fabric-ops/values.yaml
+++ b/helm-charts/fabric-ops/values.yaml
@@ -8,3 +8,8 @@ retry_seconds: 60
 tls_cert_file: /root/cert.pem
 default_msp_dir: /tmp/fabric
 filestore_ssl: false
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# Not required for identity registration, but we use the same values file for deploying fabric-tools helm chart. 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+# core_peer_mspconfigpath_override: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/admin-org/msp

--- a/helm-charts/fabric-ops/values.yaml
+++ b/helm-charts/fabric-ops/values.yaml
@@ -7,3 +7,4 @@ ttlSecondsAfterFinished: "100"
 retry_seconds: 60
 tls_cert_file: /root/cert.pem
 default_msp_dir: /tmp/fabric
+filestore_ssl: false

--- a/helm-charts/fabric-orderer/Chart.yaml
+++ b/helm-charts/fabric-orderer/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: fabric-orderer
 description: A Helm chart for deploying Fabric Orderers in Kubernetes.
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "2.4"

--- a/helm-charts/fabric-orderer/templates/cm.yaml
+++ b/helm-charts/fabric-orderer/templates/cm.yaml
@@ -127,6 +127,7 @@ data:
       echo "--------------------------------------------------------------------"
       echo "Cound not find a client certificate at {{ .Values.orderer_cert_base_dir }}/msp/signcerts/cert.pem. Looks like a fresh orderer msp cert directory, proceeding to further msp enrollment."
       echo "--------------------------------------------------------------------"
+      rm -rf {{ .Values.orderer_cert_base_dir }}/msp
       fabric_public_key_fetch $1 $4
       fabric_enroll $1 $2 $3 $4   
     fi
@@ -139,6 +140,7 @@ data:
       echo "--------------------------------------------------------------------"      
       echo "Cound not find a client certificate at {{ .Values.orderer_cert_base_dir }}/tls/signcerts/cert.pem. Looks like a fresh orderer tls cert directory, proceeding to further tls cert archive download step from filestore."
       echo "--------------------------------------------------------------------"
+      rm -rf {{ .Values.orderer_cert_base_dir }}/tls
       get_file /var/hyperledger/tls.tar.gz {{ .Values.filestore_endpoint }}/{{ $Project }}/$2-tls-certs.tar.gz
       echo "--------------------------------------------------------------------"
       echo "Rearranging tls certificate directory structure for $2"

--- a/helm-charts/fabric-orderer/templates/cm.yaml
+++ b/helm-charts/fabric-orderer/templates/cm.yaml
@@ -91,11 +91,11 @@ data:
           echo "--------------------------------------------------------------------"
           echo "Atempting to download $FILE_NAME from $FILESTORE_DOWNLOAD_URL"
           echo "--------------------------------------------------------------------"
-          if curl --silent --head --fail "$FILESTORE_DOWNLOAD_URL"; then
+          if curl --silent --head --fail "$FILESTORE_DOWNLOAD_URL" {{- if .Values.filestore_ssl  }} --insecure {{- end }}; then
             echo "--------------------------------------------------------------------"
             echo "Received success http response, downloading $FILE_NAME from $FILESTORE_DOWNLOAD_URL"
             echo "--------------------------------------------------------------------"
-            curl $FILESTORE_DOWNLOAD_URL -o $FILE_NAME
+            curl $FILESTORE_DOWNLOAD_URL -o $FILE_NAME {{- if .Values.filestore_ssl  }} --insecure {{- end }}
             echo "Received file SHA256 value is = $(sha256sum $FILE_NAME)"
             break;
           else
@@ -108,21 +108,50 @@ data:
       done
     }
 
-    get_file {{ .Values.orderer_cert_base_dir }}/{{ .Values.block_file }} {{ .Values.filestore_endpoint }}/{{ $Project }}/{{ .Values.block_file }} 
-    fabric_public_key_fetch $1 $4
-    fabric_enroll $1 $2 $3 $4       
-    get_file /var/hyperledger/tls.tar.gz {{ .Values.filestore_endpoint }}/{{ $Project }}/$2-tls-certs.tar.gz
-    echo "--------------------------------------------------------------------"
-    echo "Rearranging tls certificate directory structure for $2"
-    echo "--------------------------------------------------------------------"
-    if tar -xvf /var/hyperledger/tls.tar.gz -C {{ .Values.orderer_cert_base_dir }}/; then
-      echo "-------------------------------------------------"
-      echo "TLS directory has been configured successfully."
-      echo "-------------------------------------------------"
+    if [ -f "{{ .Values.orderer_cert_base_dir }}/{{ .Values.block_file }}" ]; then
+      echo "--------------------------------------------------------------------"
+      echo "Found a blockfile at {{ .Values.orderer_cert_base_dir }}/{{ .Values.block_file }}. Will not attempt to download the blockfile from filestore. This orderer will re-use the existing blockfile present."
+      echo "--------------------------------------------------------------------"
     else
-      echo "----------------------------------------------------------------------------------------------------------------------"
-      echo "Something went wrong, please verify the identity, make sure the tls cert for this identity is avaiable in filestore."
-      echo "----------------------------------------------------------------------------------------------------------------------"
+      echo "--------------------------------------------------------------------"
+      echo "Cound not find a blockfile at {{ .Values.orderer_cert_base_dir }}/{{ .Values.block_file }}. Looks like a fresh orderer, proceeding to further blockfile download step from filestore."
+      echo "--------------------------------------------------------------------"
+      get_file {{ .Values.orderer_cert_base_dir }}/{{ .Values.block_file }} {{ .Values.filestore_endpoint }}/{{ $Project }}/{{ .Values.block_file }}
+    fi
+
+    if [ -f "{{ .Values.orderer_cert_base_dir }}/msp/signcerts/cert.pem" ]; then
+      echo "--------------------------------------------------------------------"
+      echo "Found a client certificate at {{ .Values.orderer_cert_base_dir }}/msp/signcerts/cert.pem. Skipping the cert directory cleanup and enrollment steps. This orderer will re-use the existing msp certificates present in the msp directory."
+      echo "--------------------------------------------------------------------"
+    else
+      echo "--------------------------------------------------------------------"
+      echo "Cound not find a client certificate at {{ .Values.orderer_cert_base_dir }}/msp/signcerts/cert.pem. Looks like a fresh orderer msp cert directory, proceeding to further msp enrollment."
+      echo "--------------------------------------------------------------------"
+      fabric_public_key_fetch $1 $4
+      fabric_enroll $1 $2 $3 $4   
+    fi
+
+    if [ -f "{{ .Values.orderer_cert_base_dir }}/tls/signcerts/cert.pem" ]; then
+      echo "--------------------------------------------------------------------"
+      echo "Found a client certificate at {{ .Values.orderer_cert_base_dir }}/tls/signcerts/cert.pem. This orderer will re-use the existing tls certificates present in the tls directory."
+      echo "--------------------------------------------------------------------"
+    else
+      echo "--------------------------------------------------------------------"      
+      echo "Cound not find a client certificate at {{ .Values.orderer_cert_base_dir }}/tls/signcerts/cert.pem. Looks like a fresh orderer tls cert directory, proceeding to further tls cert archive download step from filestore."
+      echo "--------------------------------------------------------------------"
+      get_file /var/hyperledger/tls.tar.gz {{ .Values.filestore_endpoint }}/{{ $Project }}/$2-tls-certs.tar.gz
+      echo "--------------------------------------------------------------------"
+      echo "Rearranging tls certificate directory structure for $2"
+      echo "--------------------------------------------------------------------"
+       if tar -xvf /var/hyperledger/tls.tar.gz -C {{ .Values.orderer_cert_base_dir }}/; then
+         echo "-------------------------------------------------"
+         echo "TLS directory has been configured successfully."
+         echo "-------------------------------------------------"
+       else
+         echo "----------------------------------------------------------------------------------------------------------------------"
+         echo "Something went wrong, please verify the identity, make sure the tls cert for this identity is avaiable in filestore."
+         echo "----------------------------------------------------------------------------------------------------------------------"
+       fi
     fi
 
   config.yaml: |

--- a/helm-charts/fabric-orderer/templates/deployment.yaml
+++ b/helm-charts/fabric-orderer/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             claimName: cert-{{ .name }}-{{ include "fabric-orderer.fullname" $ }}
           {{- else }}
           emptyDir:
-           sizeLimit: 50Mi
+           sizeLimit: {{ $.Values.global.certStorageSize | default "50M" }}
           {{- end }}          
         - name: config
           configMap:

--- a/helm-charts/fabric-orderer/templates/deployment.yaml
+++ b/helm-charts/fabric-orderer/templates/deployment.yaml
@@ -82,8 +82,13 @@ spec:
           persistentVolumeClaim:
             claimName: data-{{ .name }}-{{ include "fabric-orderer.fullname" $ }}
         - name: certs
+          {{- if not $.Values.enroll_on_every_pod_recreation }}
+          persistentVolumeClaim:
+            claimName: cert-{{ .name }}-{{ include "fabric-orderer.fullname" $ }}
+          {{- else }}
           emptyDir:
            sizeLimit: 50Mi
+          {{- end }}          
         - name: config
           configMap:
             name: {{ include "fabric-orderer.fullname" $ }}-conf

--- a/helm-charts/fabric-orderer/templates/pvc.yaml
+++ b/helm-charts/fabric-orderer/templates/pvc.yaml
@@ -16,6 +16,22 @@ spec:
   - {{ .storageAccessMode | default ($.Values.global.storageAccessMode | default "ReadWriteOnce") }}
   resources:
     requests:
-      storage: {{ .storageSize | default ($.Values.global.storageSize | default "5Gi") }}
+      storage: {{ .dataStorageSize | default ($.Values.global.storageSize | default "5Gi") }}
   storageClassName: {{ .storageClass | default ($.Values.global.storageClass | default "default") }}
+---
+{{- if not $.Values.enroll_on_every_pod_recreation }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cert-{{ .name }}-{{ include "fabric-orderer.fullname" $ }}
+  labels:
+    {{- include "fabric-orderer.labels" $ | nindent 4 }}
+spec:
+  accessModes:
+  - {{ .storageAccessMode | default ($.Values.global.storageAccessMode | default "ReadWriteOnce") }}
+  resources:
+    requests:
+      storage: {{ .certStorageSize | default ($.Values.global.certStorageSize | default "50M") }}
+  storageClassName: {{ .storageClass | default ($.Values.global.storageClass | default "default") }}
+{{- end }}
 {{- end }}

--- a/helm-charts/fabric-orderer/values.yaml
+++ b/helm-charts/fabric-orderer/values.yaml
@@ -8,6 +8,8 @@ nameOverride: ""
 fullnameOverride: ""
 orderer_cert_base_dir: "/var/hyperledger/orderer"
 orderer_data_dir: "/var/hyperledger/production"
+enroll_on_every_pod_recreation: true
+filestore_ssl: false
 podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000

--- a/helm-charts/fabric-peer/Chart.yaml
+++ b/helm-charts/fabric-peer/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: fabric-peer
 description: A Helm chart for deploying Fabric Peers in Kubernetes.
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "2.4"

--- a/helm-charts/fabric-peer/templates/peer-cm.yaml
+++ b/helm-charts/fabric-peer/templates/peer-cm.yaml
@@ -130,7 +130,18 @@ data:
     done
     }
 
-    fabric_public_key_fetch $1 $5
-    fabric_msp_enroll $1 $3 $4 $5
-    fabric_public_key_fetch $2 $6
-    fabric_tls_enroll $2 $3 $4 $6
+    if [ -f "{{ .Values.fabric_base_dir }}/msp/signcerts/cert.pem" ]; then
+      echo "Found a client certificate at {{ .Values.fabric_base_dir }}/msp/signcerts/cert.pem. Skipping the cert directory cleanup and enrollment steps. Peer will re-use the existing msp certificates present in the msp directory."
+    else
+      echo "Cound not find a client certificate at {{ .Values.fabric_base_dir }}/msp/signcerts/cert.pem. Looks like a fresh peer msp cert directory, proceeding to further msp enrollment."
+      fabric_public_key_fetch $1 $5
+      fabric_msp_enroll $1 $3 $4 $5
+    fi
+
+    if [ -f "{{ .Values.fabric_base_dir }}/tls/signcerts/cert.pem" ]; then
+      echo "Found a client certificate at {{ .Values.fabric_base_dir }}/tls/signcerts/cert.pem. Skipping the cert directory cleanup and enrollment steps. Peer will re-use the existing tls certificates present in the tls directory."
+    else
+      echo "Cound not find a client certificate at {{ .Values.fabric_base_dir }}/tls/signcerts/cert.pem. Looks like a fresh peer tls cert directory, proceeding to further tls enrollment."
+      fabric_public_key_fetch $2 $6
+      fabric_tls_enroll $2 $3 $4 $6
+    fi

--- a/helm-charts/fabric-peer/templates/peer-cm.yaml
+++ b/helm-charts/fabric-peer/templates/peer-cm.yaml
@@ -146,6 +146,7 @@ data:
       echo "----------------------------------------------------------"
       echo "Cound not find a client certificate at {{ .Values.fabric_base_dir }}/msp/signcerts/cert.pem. Looks like a fresh peer msp cert directory, proceeding to further msp enrollment."
       echo "----------------------------------------------------------"
+      rm -rf {{ .Values.fabric_base_dir }}/msp/
       fabric_public_key_fetch $1 $5
       fabric_msp_enroll $1 $3 $4 $5
     fi
@@ -158,6 +159,7 @@ data:
       echo "----------------------------------------------------------"
       echo "Cound not find a client certificate at {{ .Values.fabric_base_dir }}/tls/signcerts/cert.pem. Looks like a fresh peer tls cert directory, proceeding to further tls enrollment."
       echo "----------------------------------------------------------"
+      rm -rf {{ .Values.fabric_base_dir }}/tls/
       fabric_public_key_fetch $2 $6
       fabric_tls_enroll $2 $3 $4 $6
     fi

--- a/helm-charts/fabric-peer/templates/peer-cm.yaml
+++ b/helm-charts/fabric-peer/templates/peer-cm.yaml
@@ -36,22 +36,22 @@ data:
     while true; do
       http_response=$(curl -sL -w  "%{http_code}" "https://$FABRIC_CA_URL/cainfo" --insecure -o /dev/null)
       if [ "$http_response" -eq "200" ]; then
-        echo "--------------------------------"
+        echo "----------------------------------------------------------"
         echo "Fetching public key cert of https://$FABRIC_CA_URL, received HTTP response with 200."
-        echo "--------------------------------"
+        echo "----------------------------------------------------------"
           if curl https://$FABRIC_CA_URL/cainfo --insecure | jq .result.CAChain | base64 -i -d > $FABRIC_TLS_CERT_FILE; then
-            echo "--------------------------------"
+            echo "----------------------------------------------------------"
             echo "The downloaded public key cert of https://$FABRIC_CA_URL"
-            echo "--------------------------------"
+            echo "----------------------------------------------------------"
             cat $FABRIC_TLS_CERT_FILE
             break;
           else
             echo "There are some issues with fetching the public key using 'jq' OR 'curl' command."
           fi
       else
-        echo "------------------------------------"
+        echo "----------------------------------------------------------"
         echo "Fetching public key cert of https://$FABRIC_CA_URL, but received non 200 HTTP response $http_response. Init container will retry until it gets 200 response from https://$FABRIC_CA_URL. Cannot proceed without the public key cert. "
-        echo "------------------------------------"
+        echo "----------------------------------------------------------"
         sleep {{ .Values.retry_seconds }}
       fi
     done
@@ -65,9 +65,9 @@ data:
     FABRIC_TLS_CERT_FILE=$4
 
     while true; do
-      echo "------------------------------------"
+      echo "----------------------------------------------------------"
       echo "Enrolling $FABRIC_CA_IDENTITY to $FABRIC_CA_URL"
-      echo "------------------------------------"
+      echo "----------------------------------------------------------"
       fabric-ca-client enroll \
             --url https://$FABRIC_CA_IDENTITY:$FABRIC_CA_SECRET@$FABRIC_CA_URL \
             --mspdir {{ .Values.fabric_base_dir }}/msp \
@@ -75,18 +75,18 @@ data:
             --csr.hosts $FABRIC_CA_IDENTITY,$FABRIC_CA_IDENTITY.{{ $HlfDomain }} \
             --csr.names O='{{ .Values.csr_names_o }}',L={{ .Values.csr_names_l }},ST={{ .Values.csr_names_st }},C={{ .Values.csr_names_cn }}
       if [ $? -eq 0 ]; then
-        echo "------------------------------------"
+        echo "----------------------------------------------------------"
         echo "Identity $FABRIC_CA_IDENTITY is valid and enrollment is successful. Rearranging msp certificate directory structure for $FABRIC_CA_IDENTITY"
-        echo "--------------------------------------"
+        echo "----------------------------------------------------------"
         cp {{ .Values.fabric_base_dir }}/msp/intermediatecerts/* {{ .Values.fabric_base_dir }}/msp/intermediatecerts/ca-cert.pem
-        echo "-------------------------------------------------"
+        echo "----------------------------------------------------------"
         echo "MSP directory has been configured successfully."
-        echo "-------------------------------------------------"
+        echo "----------------------------------------------------------"
         break;
       else
-        echo "------------------------------------"
+        echo "----------------------------------------------------------"
         echo "Cannot login with the given Identity $FABRIC_CA_IDENTITY, will retry in {{ .Values.retry_seconds }} seconds. Meanwhile kindly verify the identities and endpoints"
-        echo "------------------------------------"
+        echo "----------------------------------------------------------"
         sleep {{ .Values.retry_seconds }}
       fi
     done
@@ -100,9 +100,9 @@ data:
     FABRIC_TLS_CERT_FILE=$4
 
     while true; do
-      echo "------------------------------------"
+      echo "----------------------------------------------------------"
       echo "Enrolling $FABRIC_CA_IDENTITY to $FABRIC_CA_URL"
-      echo "------------------------------------"
+      echo "----------------------------------------------------------"
       fabric-ca-client enroll \
             --url https://$FABRIC_CA_IDENTITY:$FABRIC_CA_SECRET@$FABRIC_CA_URL \
             --mspdir {{ .Values.fabric_base_dir }}/tls \
@@ -111,37 +111,54 @@ data:
             --enrollment.profile tls \
             --csr.names O='{{ .Values.csr_names_o }}',L={{ .Values.csr_names_l }},ST={{ .Values.csr_names_st }},C={{ .Values.csr_names_cn }}
       if [ $? -eq 0 ]; then
-        echo "------------------------------------"
+        echo "----------------------------------------------------------"
         echo "Identity $FABRIC_CA_IDENTITY is valid and enrollment is successful. Rearranging tls certificate directory structure for $FABRIC_CA_IDENTITY"
-        echo "--------------------------------------"
+        echo "----------------------------------------------------------"
         cp {{ .Values.fabric_base_dir }}/tls/tlscacerts/* {{ .Values.fabric_base_dir }}/tls/ca.crt;
         cp {{ .Values.fabric_base_dir }}/tls/signcerts/* {{ .Values.fabric_base_dir }}/tls/server.crt;
         cp {{ .Values.fabric_base_dir }}/tls/keystore/* /{{ .Values.fabric_base_dir }}/tls/server.key;
-        echo "-------------------------------------------------"
+        echo "----------------------------------------------------------"
         echo "TLS directory has been configured successfully."
-        echo "-------------------------------------------------"
+        echo "----------------------------------------------------------"
         break;
       else
-        echo "------------------------------------"
+        echo "----------------------------------------------------------"
         echo "Cannot login with the given Identity $FABRIC_CA_IDENTITY, will retry in {{ .Values.retry_seconds }} seconds. Meanwhile kindly verify the identities and endpoints"
-        echo "------------------------------------"
+        echo "----------------------------------------------------------"
         sleep {{ .Values.retry_seconds }}
       fi
     done
     }
 
+    {{- if .Values.renew_peer_certs }}
+    echo "----------------------------------------------------------"
+    echo "Peer cert renewal is set to true at Values.renew_peer_certs. This will remove the existing peer msp/tls certificates and generate new certs."
+    echo "----------------------------------------------------------"
+    rm -rf {{ .Values.fabric_base_dir }}/msp/
+    rm -rf {{ .Values.fabric_base_dir }}/tls/
+    {{- end }}
+
     if [ -f "{{ .Values.fabric_base_dir }}/msp/signcerts/cert.pem" ]; then
+      echo "----------------------------------------------------------"
       echo "Found a client certificate at {{ .Values.fabric_base_dir }}/msp/signcerts/cert.pem. Skipping the cert directory cleanup and enrollment steps. Peer will re-use the existing msp certificates present in the msp directory."
+      echo "----------------------------------------------------------"
     else
+      echo "----------------------------------------------------------"
       echo "Cound not find a client certificate at {{ .Values.fabric_base_dir }}/msp/signcerts/cert.pem. Looks like a fresh peer msp cert directory, proceeding to further msp enrollment."
+      echo "----------------------------------------------------------"
       fabric_public_key_fetch $1 $5
       fabric_msp_enroll $1 $3 $4 $5
     fi
 
     if [ -f "{{ .Values.fabric_base_dir }}/tls/signcerts/cert.pem" ]; then
+      echo "----------------------------------------------------------"
       echo "Found a client certificate at {{ .Values.fabric_base_dir }}/tls/signcerts/cert.pem. Skipping the cert directory cleanup and enrollment steps. Peer will re-use the existing tls certificates present in the tls directory."
+      echo "----------------------------------------------------------"
     else
+      echo "----------------------------------------------------------"
       echo "Cound not find a client certificate at {{ .Values.fabric_base_dir }}/tls/signcerts/cert.pem. Looks like a fresh peer tls cert directory, proceeding to further tls enrollment."
+      echo "----------------------------------------------------------"
       fabric_public_key_fetch $2 $6
       fabric_tls_enroll $2 $3 $4 $6
     fi
+

--- a/helm-charts/fabric-peer/templates/peer-sts.yaml
+++ b/helm-charts/fabric-peer/templates/peer-sts.yaml
@@ -48,7 +48,7 @@ spec:
           args:
            - /scripts/enroll.sh {{ $IcaEndpoint }} {{ $TlsCaEndpoint }} {{ .identity_name }} {{ .identity_secret }} {{ $.Values.ica_tls_cert_file }} {{ $.Values.tlsca_tls_cert_file }}
           volumeMounts:
-           - name: certs
+           - name: cert-peer
              mountPath: {{ $.Values.fabric_base_dir }}
            - name: config
              mountPath: /scripts/enroll.sh
@@ -172,23 +172,25 @@ spec:
           volumeMounts:
             - name: data-peer
               mountPath: {{ .peerDataDir | default $.Values.global.peerDataDir }}
-            - name: certs
+            - name: cert-peer
               mountPath: {{ $.Values.fabric_base_dir }}/msp
               subPath: msp
-            - name: certs
+            - name: cert-peer
               mountPath: {{ $.Values.fabric_base_dir }}/tls
               subPath: tls
             - name: config
               mountPath: {{ $.Values.fabric_base_dir }}/msp/config.yaml
               subPath: config.yaml
       volumes:
-        - name: certs
-          emptyDir:
-           sizeLimit: 100Mi
         - name: config
           configMap:
             name: {{ include "fabric-peer.fullname" $ }}-fabric-ops
             defaultMode: 0777
+        {{- if $.Values.enroll_on_every_pod_recreation }}
+        - name: cert-peer
+          emptyDir:
+           sizeLimit: {{ $.Values.global.peerCertDiskSize }}
+        {{- end }}
       {{- with .nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -231,4 +233,15 @@ spec:
         requests:
           storage: {{ .peerDiskSize | default $.Values.global.peerDiskSize }}
       storageClassName: {{ .peerStorageClass | default $.Values.global.storageClass }}
+{{- if not $.Values.enroll_on_every_pod_recreation }}
+  - metadata:
+      name: cert-peer
+    spec:
+      accessModes:
+      - {{ .peerPvcAccessMode | default $.Values.global.peerPvcAccessMode }}
+      resources:
+        requests:
+          storage: {{ .peerCertDiskSize | default $.Values.global.peerCertDiskSize }}
+      storageClassName: {{ .peerStorageClass | default $.Values.global.storageClass }}
+{{- end }}
 {{- end }}

--- a/helm-charts/fabric-peer/templates/peer-sts.yaml
+++ b/helm-charts/fabric-peer/templates/peer-sts.yaml
@@ -79,7 +79,7 @@ spec:
           ports:
             - containerPort: {{ .couchContainerPort | default $.Values.global.couchContainerPort }}
           volumeMounts:
-            - name: data-couchdb
+            - name: {{ (.couchUseExistingPvcPrefix | default $.Values.global.couchUseExistingPvcPrefix) | default "data-couchdb" }}
               mountPath: {{ .couchDataDir | default $.Values.global.couchDataDir }}
         {{- end }}
         - name: dind-daemon
@@ -106,7 +106,7 @@ spec:
           securityContext:
               {{- toYaml $.Values.global.dindSecurityContext | nindent 12 }}
           volumeMounts:
-            - name: data-graph
+            - name: {{ (.dindUseExistingPvcPrefix | default $.Values.global.dindUseExistingPvcPrefix) | default "data-dind" }}
               mountPath: {{ .dindDataDir | default $.Values.global.dindDataDir }}
         - name: peer
           securityContext:
@@ -170,7 +170,7 @@ spec:
           resources:
             {{- toYaml (.peerResources | default $.Values.global.peerResources) | nindent 12 }}
           volumeMounts:
-            - name: data-peer
+            - name: {{ (.peerUseExistingPvcPrefix | default $.Values.global.peerUseExistingPvcPrefix) | default "data-peer" }}
               mountPath: {{ .peerDataDir | default $.Values.global.peerDataDir }}
             - name: cert-peer
               mountPath: {{ $.Values.fabric_base_dir }}/msp
@@ -206,7 +206,7 @@ spec:
   volumeClaimTemplates:
   {{- if .useCouchDB | default $.Values.global.useCouchDB }}
   - metadata:
-      name: data-couchdb
+      name: {{ (.couchUseExistingPvcPrefix | default $.Values.global.couchUseExistingPvcPrefix) | default "data-couchdb" }}
     spec:
       accessModes:
       - {{ .couchPvcAccessMode | default $.Values.global.couchPvcAccessMode }}
@@ -216,7 +216,7 @@ spec:
       storageClassName: {{ .couchStorageClass | default $.Values.global.storageClass }} 
   {{- end }}
   - metadata:
-      name: data-graph
+      name: {{ (.dindUseExistingPvcPrefix | default $.Values.global.dindUseExistingPvcPrefix) | default "data-dind" }}
     spec:
       accessModes:
       - {{ .dindPvcAccessMode | default $.Values.global.dindPvcAccessMode }}
@@ -225,7 +225,7 @@ spec:
           storage: {{ .dindDiskSize | default $.Values.global.dindDiskSize }}
       storageClassName: {{ .dindStorageClass | default $.Values.global.storageClass }}
   - metadata:
-      name: data-peer
+      name: {{ (.peerUseExistingPvcPrefix | default $.Values.global.peerUseExistingPvcPrefix) | default "data-peer" }}
     spec:
       accessModes:
       - {{ .peerPvcAccessMode | default $.Values.global.peerPvcAccessMode }}

--- a/helm-charts/fabric-peer/values.yaml
+++ b/helm-charts/fabric-peer/values.yaml
@@ -11,13 +11,12 @@ fullnameOverride: ""
 ica_tls_cert_file: /root/ica-cert.pem
 tlsca_tls_cert_file: /root/tlsca-cert.pem
 fabric_base_dir: /etc/hyperledger/fabric
+enroll_on_every_pod_recreation: true
 retry_seconds: 60
 
 podAnnotations: {}
-
 podSecurityContext: {}
   # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -25,7 +24,6 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
-
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -37,7 +35,6 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-
 autoscaling:
 nodeSelector: {}
 tolerations: []

--- a/helm-charts/fabric-peer/values.yaml
+++ b/helm-charts/fabric-peer/values.yaml
@@ -20,6 +20,7 @@ ica_tls_cert_file: /root/ica-cert.pem
 tlsca_tls_cert_file: /root/tlsca-cert.pem
 fabric_base_dir: /etc/hyperledger/fabric
 enroll_on_every_pod_recreation: true
+renew_peer_certs: false
 retry_seconds: 60
 
 podAnnotations: {}

--- a/helm-charts/fabric-peer/values.yaml
+++ b/helm-charts/fabric-peer/values.yaml
@@ -8,6 +8,14 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# peers:
+#   - name: peer0
+#     identity_name: peer0-org
+#     identity_secret: peer0orgSamplePassword
+#     couchUseExistingPvcPrefix: couch-pvc # If you want to use an existing pvc for Couch. A pvc must exists with name couch-pvc-peer0-org-0
+#     peerUseExistingPvcPrefix: peer-pvc # If you want to use an existing pvc for Peer. A pvc must exists with name peer-pvc-peer0-org-0
+#     dindUseExistingPvcPrefix: dind-pvc # If you want to use an existing pvc for Dind. A pvc must exists with name dind-pvc-peer0-org1-0
+
 ica_tls_cert_file: /root/ica-cert.pem
 tlsca_tls_cert_file: /root/tlsca-cert.pem
 fabric_base_dir: /etc/hyperledger/fabric

--- a/helm-charts/fabric-tools/Chart.yaml
+++ b/helm-charts/fabric-tools/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: fabric-tools
 description: A Helm chart for deploying Fabric cli tools in Kubernetes.
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "1.5.0"

--- a/helm-charts/fabric-tools/templates/deployment.yaml
+++ b/helm-charts/fabric-tools/templates/deployment.yaml
@@ -3,7 +3,8 @@ Copyright National Payments Corporation of India. All Rights Reserved.
 SPDX-License-Identifier:  GPL-3.0
 */}}
 
-{{ $BankName := .Values.nameOverride }}
+{{ $BankName               := .Values.nameOverride }}
+{{ $CorePeerMspConfigPath  := printf "%s%s" .Values.workdir "/peer/crypto/users/admin/msp" }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -52,7 +53,7 @@ spec:
             - name: CORE_PEER_LOCALMSPID
               value: {{ $BankName }}
             - name: CORE_PEER_MSPCONFIGPATH
-              value: {{ $.Values.workdir }}/peer/crypto/users/admin/msp
+              value: {{ $.Values.core_peer_mspconfigpath_override | default $CorePeerMspConfigPath }}
             - name: CORE_PEER_TLS_CERT_FILE
               value: {{ $.Values.workdir }}/peer/crypto/users/peer0-{{ $BankName }}/tls/server.crt
             - name: CORE_PEER_TLS_ENABLED

--- a/helm-charts/fabric-tools/values.yaml
+++ b/helm-charts/fabric-tools/values.yaml
@@ -3,6 +3,10 @@
 
 workdir: /opt/gopath/src/github.com/hyperledger/fabric
 peer_internal_service_port: "30002"
+# .Values.core_peer_mspconfigpath_override - Use only if your admin username is not "admin". 
+# This must be under /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/
+# Eg; /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/users/<admin-user>/msp
+core_peer_mspconfigpath_override: ""
 tools:
   storageAccessMode: ReadWriteOnce
   storageSize: "5Gi"

--- a/helm-charts/filestore/Chart.yaml
+++ b/helm-charts/filestore/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: filestore
 description: A Helm chart for deploying an Nginx file sharing web server in Kubernetes.
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "1.16.0"

--- a/helm-charts/filestore/templates/ingress.yaml
+++ b/helm-charts/filestore/templates/ingress.yaml
@@ -4,8 +4,9 @@ SPDX-License-Identifier:  GPL-3.0
 */}}
 
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "filestore.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $fullName    := include "filestore.fullname" . -}}
+{{- $defaultHost := printf "%s.%s" ( include "filestore.fullname" . ) .Values.global.hlf_domain -}}
+{{- $svcPort     := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
@@ -33,17 +34,13 @@ spec:
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+        - {{ $.Values.hostOverride | default $defaultHost }}
+      secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ include "filestore.fullname" $ }}.{{ $.Values.global.hlf_domain }}
+    - host: {{ $.Values.hostOverride | default $defaultHost }}
       http:
         paths:
           {{- range .paths }}

--- a/helm-charts/filestore/values.yaml
+++ b/helm-charts/filestore/values.yaml
@@ -39,6 +39,14 @@ service:
   type: ClusterIP
   port: 80
 
+# You need to add a resolvable DNS entry here. An ingress resource will be created based on this domain. 
+# Eg; domain.com, then the ingress will be created "filestore.domain.com"
+global:
+ hlf_domain: "my-hlf-domain.com"
+
+# If you want to override the global.hlf_domain FQDN and use your own FQDN, then use this.
+hostOverride: "custom.filestore.com" 
+
 ingress:
   enabled: true
   className: "nginx"
@@ -47,6 +55,8 @@ ingress:
     - paths:
         - path: /
           pathType: Prefix
+  # tls:
+  #  secretName: my-hlf-domain-ssl-certs
 
 resources: {}
   # limits:
@@ -56,16 +66,10 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-# You need to add a resolvable DNS entry here. An ingress resource will be created based ont this domain. 
-# Eg; domain.com, then the ingress will be created "filestore.domain.com"
-global:
- hlf_domain: "my-hlf-domain.com"
-
 storage:
  size: 1G
  accessMode: ReadWriteOnce
  storageClass: standard
-
 
 autoscaling:
   enabled: false

--- a/helm-charts/filestore/values.yaml
+++ b/helm-charts/filestore/values.yaml
@@ -45,7 +45,7 @@ global:
  hlf_domain: "my-hlf-domain.com"
 
 # If you want to override the global.hlf_domain FQDN and use your own FQDN, then use this.
-hostOverride: "custom.filestore.com" 
+# hostOverride: "custom.filestore.com" 
 
 ingress:
   enabled: true


### PR DESCRIPTION
### v1.0.2 features:

- Peers & Orderes charts
  - Added a new feature to skip msp/tls enrollments on every pod recreation through the boolean variable `enroll_on_every_pod_recreation`. If set to `true`, (by default) then deployment/sts will use an emptydir ephemeral volume for storing the certs and on every pod re-creation the init container performs the enrollment. If set to `false`, a pvc will be created from the given storageclass and stores the certificates there. On pod recreation, the init script checks the existence of the certs and skip the enrollment if the the certs exists. 
  - This will remove the dependency on the CA Server when a peer/orderer pod  gets recreated due to any node failure. (But for the very first deployment, the CA server end-point should be available.)
- Filestore chart
  - Added custom hostname/fqdn support for the filestore endpoint. This will remove the dependency on running filestore end-point with the same HLF domain. You can override the default chart generated filestore endpoint with any resolvable dns (If you have one already) using the `.Values.hostOverride` with your own FQDN.
  - Added optional TLS support for the filestore ingress resource. To do that, create a kubenetes secret of tls type and provide it here in `.Values.ingress.tls.secretName`
- Peer
  - New option to renew peer certificates. Set `.Values.renew_peer_certs: true ` to delete the existing certificates and generate new certs through an enrollment. Once the certs got renewed, change this to false again via a helm upgrade. Make this to true only when you want to renew the certs. 
  - Added a feature to use existing PVCs for peer,dind & couchdb containers. So that falcon can be integrated into an already running peer without any data lose if it was not managed through falcon peer charts. Use the following vars under `.Values.peers` array to specify the existing volumes per peer OR you can add it under `.Values.global` for all peers. Do a comparison by running `helm template` and verify the output before you deploy it. The volume name prefix under the `volumeClaimTemplates.metadata.name` of your sts must match with the existing pvc. 
Example:
```
  peers:
    - name: peer0
      identity_name: peer0-org
      identity_secret: peer0orgSamplePassword
      couchUseExistingPvcPrefix: couch-pvc
      peerUseExistingPvcPrefix: peer-pvc
      dindUseExistingPvcPrefix: dind-pvc
```
By specifying the above values, the chart assumes that a pvc exists already with the name `couch-pvc-peer0-org-0` for the `peer0`.