### PR TITLE
Added servicemonitor, metrics support and operations svc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 **/.DS_Store
+
+# VSCode local workspace configurations
+.vscode

--- a/examples/fabric-orderer/orderer.yaml
+++ b/examples/fabric-orderer/orderer.yaml
@@ -56,6 +56,46 @@ global:
   storageAccessMode: ReadWriteOnce
   storageSize: "10Gi"
   storageClass: standard
+
+  ## Configuration for the Operations Service: https://hyperledger-fabric.readthedocs.io/en/latest/operations_service.html
+  operations:
+    serviceName: operations
+    serviceType: ClusterIP
+    servicePort: 8443
+
+  metrics:
+    ## Select metrics provider. Possible values are "prometheus", "statsd" or "disabled"
+    provider: prometheus
+
+    ## Only applicable if provider is "prometheus"
+    ## A serviceMonitor will be created for each peer with the configuration provided below
+    serviceMonitor:
+      enabled: true
+      additionalLabels: {}
+      namespace: ""
+
+      ## This should be equal to the operations port name
+      portName: operations
+      scrapeInterval: 30s
+      honorLabels: true
+      relabelings: []
+      metricRelabelings: []
+
+      ## Default: scrape .Release.Namespace only
+      ## To scrape all, use the following:
+      ## namespaceSelector:
+      ##   any: true
+      namespaceSelector:
+        any: true
+      targetLabels: []
+    
+    ## Configuration for statsd provider
+    ## Statsd prefix will be the peer identity name
+    statsd:
+      network: udp
+      address: 127.0.0.1:8125
+      writeInterval: 10s
+
   env:
     - name: FABRIC_LOGGING_SPEC
       value: INFO

--- a/examples/fabric-peer/initialpeerorg/values.yaml
+++ b/examples/fabric-peer/initialpeerorg/values.yaml
@@ -48,7 +48,46 @@ global:
   imagePullPolicy: Always
   serviceAccount:
     annotations: []
-   
+
+  ## Configuration for the Operations Service: https://hyperledger-fabric.readthedocs.io/en/latest/operations_service.html
+  operations:
+    serviceName: operations
+    serviceType: ClusterIP
+    servicePort: 9443
+
+  metrics:
+    ## Select metrics provider. Possible values are "prometheus", "statsd" or "disabled"
+    provider: disabled
+
+    ## Only applicable if provider is "prometheus"
+    ## A serviceMonitor will be created for each peer with the configuration provided below
+    serviceMonitor:
+      enabled: false
+      additionalLabels: {}
+      namespace: ""
+
+      ## This should be equal to the operations port name
+      portName: operations
+      scrapeInterval: 30s
+      honorLabels: true
+      relabelings: []
+      metricRelabelings: []
+
+      ## Default: scrape .Release.Namespace only
+      ## To scrape all, use the following:
+      ## namespaceSelector:
+      ##   any: true
+      namespaceSelector:
+        any: true
+      targetLabels: []
+    
+    ## Configuration for statsd provider
+    ## Statsd prefix will be the peer identity name
+    statsd:
+      network: udp
+      address: 127.0.0.1:8125
+      writeInterval: 10s
+
   useCouchDB: true
   couchImageRegistry: docker.io
   couchImageRepo: couchdb
@@ -171,5 +210,3 @@ additonalEnvironmentVars:
       value: http://localhost:2375
     - name: DOCKER_HOST
       value: tcp://localhost:2375
-    - name: CORE_OPERATIONS_LISTENADDRESS
-      value: 0.0.0.0:9443

--- a/examples/fabric-peer/org1/values.yaml
+++ b/examples/fabric-peer/org1/values.yaml
@@ -48,6 +48,45 @@ global:
   imagePullPolicy: Always
   serviceAccount:
     annotations: []
+
+  ## Configuration for the Operations Service: https://hyperledger-fabric.readthedocs.io/en/latest/operations_service.html
+  operations:
+    serviceName: operations
+    serviceType: ClusterIP
+    servicePort: 9443
+
+  metrics:
+    ## Select metrics provider. Possible values are "prometheus", "statsd" or "disabled"
+    provider: disabled
+
+    ## Only applicable if provider is "prometheus"
+    ## A serviceMonitor will be created for each peer with the configuration provided below
+    serviceMonitor:
+      enabled: false
+      additionalLabels: {}
+      namespace: ""
+
+      ## This should be equal to the operations port name
+      portName: operations
+      scrapeInterval: 30s
+      honorLabels: true
+      relabelings: []
+      metricRelabelings: []
+
+      ## Default: scrape .Release.Namespace only
+      ## To scrape all, use the following:
+      ## namespaceSelector:
+      ##   any: true
+      namespaceSelector:
+        any: true
+      targetLabels: []
+    
+    ## Configuration for statsd provider
+    ## Statsd prefix will be the peer identity name
+    statsd:
+      network: udp
+      address: 127.0.0.1:8125
+      writeInterval: 10s
   
   useCouchDB: true
   couchImageRegistry: docker.io

--- a/examples/fabric-peer/org2/values.yaml
+++ b/examples/fabric-peer/org2/values.yaml
@@ -45,7 +45,46 @@ global:
   imagePullPolicy: Always
   serviceAccount:
     annotations: []
-  
+
+  ## Configuration for the Operations Service: https://hyperledger-fabric.readthedocs.io/en/latest/operations_service.html
+  operations:
+    serviceName: operations
+    serviceType: ClusterIP
+    servicePort: 9443
+
+  metrics:
+    ## Select metrics provider. Possible values are "prometheus", "statsd" or "disabled"
+    provider: disabled
+
+    ## Only applicable if provider is "prometheus"
+    ## A serviceMonitor will be created for each peer with the configuration provided below
+    serviceMonitor:
+      enabled: false
+      additionalLabels: {}
+      namespace: ""
+
+      ## This should be equal to the operations port name
+      portName: operations
+      scrapeInterval: 30s
+      honorLabels: true
+      relabelings: []
+      metricRelabelings: []
+
+      ## Default: scrape .Release.Namespace only
+      ## To scrape all, use the following:
+      ## namespaceSelector:
+      ##   any: true
+      namespaceSelector:
+        any: true
+      targetLabels: []
+    
+    ## Configuration for statsd provider
+    ## Statsd prefix will be the peer identity name
+    statsd:
+      network: udp
+      address: 127.0.0.1:8125
+      writeInterval: 10s
+
   useCouchDB: true
   couchImageRegistry: docker.io
   couchImageRepo: couchdb

--- a/helm-charts/fabric-orderer/templates/deployment.yaml
+++ b/helm-charts/fabric-orderer/templates/deployment.yaml
@@ -64,7 +64,23 @@ spec:
           args:
             - orderer
           env:
+            - name: ORDERER_OPERATIONS_LISTENADDRESS
+              value: 0.0.0.0:8443
             {{- tpl (toYaml $.Values.global.env) $ | nindent 12 }}
+            - name: ORDERER_METRICS_PROVIDER
+            {{- if eq "prometheus" $.Values.global.metrics.provider }}
+              value: "prometheus"
+            {{- else if eq "statsd" $.Values.global.metrics.provider }}
+              value: "statsd"
+            - name: ORDERER_METRICS_STATSD_NETWORK
+              value: {{ $.Values.global.metrics.statsd.network }}
+            - name: ORDERER_METRICS_STATSD_ADDRESS
+              value: {{ $.Values.global.metrics.statsd.address }}
+            - name: ORDERER_METRICS_STATSD_WRITEINTERVAL
+              value: {{ $.Values.global.metrics.statsd.writeInterval }}
+            {{- else }}
+              value: "disabled"
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ $.Values.global.containerPort }}

--- a/helm-charts/fabric-orderer/templates/service.yaml
+++ b/helm-charts/fabric-orderer/templates/service.yaml
@@ -22,4 +22,23 @@ spec:
   selector:
     {{- include "fabric-orderer.selectorLabels" $ | nindent 4 }}
     app: {{ .name }}-{{ include "fabric-orderer.fullname" $ }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: operations-{{ .name }}-{{ include "fabric-orderer.fullname" $ }}
+  labels:
+    orderer: {{ .identity_name }}
+    {{- include "fabric-orderer.labels" $ | nindent 4 }}
+    app: {{ .name }}-{{ include "fabric-orderer.fullname" $ }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ $.Values.global.operations.servicePort }}
+      targetPort: 8443
+      protocol: TCP
+      name: {{ $.Values.global.operations.serviceName }}
+  selector:
+    {{- include "fabric-orderer.selectorLabels" $ | nindent 4 }}
+    app: {{ .name }}-{{ include "fabric-orderer.fullname" $ }}
 {{- end }}

--- a/helm-charts/fabric-orderer/templates/servicemonitor.yaml
+++ b/helm-charts/fabric-orderer/templates/servicemonitor.yaml
@@ -1,0 +1,48 @@
+{{- if and (eq "prometheus" $.Values.global.metrics.provider) $.Values.global.metrics.serviceMonitor.enabled }}
+{{- range .Values.orderers }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .name }}-{{ include "fabric-orderer.name" $ }}
+  labels:
+    orderer: {{ .identity_name }}
+    {{- include "fabric-orderer.labels" $ | nindent 4 }}
+  {{- if $.Values.global.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml $.Values.global.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+  {{- end }}
+{{- if $.Values.global.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.global.metrics.serviceMonitor.namespace | quote }}
+{{- end }}
+spec:
+  endpoints:
+    - port: {{ $.Values.global.metrics.serviceMonitor.portName }}
+      interval: {{ $.Values.global.metrics.serviceMonitor.scrapeInterval }}
+    {{- if $.Values.global.metrics.serviceMonitor.honorLabels }}
+      honorLabels: true
+    {{- end }}
+    {{- if $.Values.global.metrics.serviceMonitor.relabelings }}
+      relabelings: {{ toYaml $.Values.global.metrics.serviceMonitor.relabelings | nindent 8 }}
+    {{- end }}
+    {{- if $.Values.global.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml $.Values.global.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
+  jobLabel: {{ .identity_name }}
+{{- if $.Values.global.metrics.serviceMonitor.namespaceSelector }}
+  namespaceSelector: {{ toYaml $.Values.global.metrics.serviceMonitor.namespaceSelector | nindent 4 }}
+{{- else }}
+  namespaceSelector:
+    matchNames:
+      - {{ $.Release.Namespace }}
+{{- end }}
+{{- if $.Values.global.metrics.serviceMonitor.targetLabels }}
+  targetLabels:
+  {{- range $.Values.global.metrics.serviceMonitor.targetLabels }}
+    - {{ $ }}
+  {{- end }}
+{{- end }}
+  selector:
+    matchLabels:
+      orderer: {{ .identity_name }}
+{{- end }}
+{{- end }}

--- a/helm-charts/fabric-peer/templates/peer-service.yaml
+++ b/helm-charts/fabric-peer/templates/peer-service.yaml
@@ -20,10 +20,6 @@ spec:
       port: {{ .peerServicePort | default $.Values.global.peerServicePort }}
       targetPort: 7051
       protocol: TCP
-    - name: health
-      port: 9443
-      targetPort: 9443
-      protocol: TCP
   selector:
     app: {{ .name }}-{{ include "fabric-peer.name" $ }}
     {{- include "fabric-peer.selectorLabels" $ | nindent 4 }}
@@ -47,4 +43,22 @@ spec:
     app: {{ .name }}-{{ include "fabric-peer.name" $ }}
     {{- include "fabric-peer.selectorLabels" $ | nindent 4 }}
 {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: operations-{{ .name }}-{{ include "fabric-peer.name" $ }}
+  labels:
+    peer: {{ .identity_name }}
+    {{- include "fabric-peer.labels" $ | nindent 4 }}
+spec:
+  type: {{ .operationsServiceType | default $.Values.global.operations.serviceType }}
+  ports:
+    - name: {{ .operationsServiceName | default $.Values.global.operations.serviceName }}
+      port: {{ .operationsServicePort | default $.Values.global.operations.servicePort }}
+      targetPort: 9443
+      protocol: TCP
+  selector:
+    app: {{ .name }}-{{ include "fabric-peer.name" $ }}
+    {{- include "fabric-peer.selectorLabels" $ | nindent 4 }}
 {{- end }}

--- a/helm-charts/fabric-peer/templates/peer-sts.yaml
+++ b/helm-charts/fabric-peer/templates/peer-sts.yaml
@@ -158,6 +158,24 @@ spec:
             - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
               value: {{ .core_ledger_state_couchdbconfig_couchdbaddress | default $.Values.global.core_ledger_state_couchdbconfig_couchdbaddress | quote }}
             {{- end }}
+            - name: CORE_OPERATIONS_LISTENADDRESS
+              value: 0.0.0.0:9443
+            - name: CORE_METRICS_PROVIDER
+            {{- if eq "prometheus" $.Values.global.metrics.provider }}
+              value: "prometheus"
+            {{- else if eq "statsd" $.Values.global.metrics.provider }}
+              value: "statsd"
+            - name: CORE_METRICS_STATSD_NETWORK
+              value: {{ $.Values.global.metrics.statsd.network }}
+            - name: CORE_METRICS_STATSD_ADDRESS
+              value: {{ $.Values.global.metrics.statsd.address }}
+            - name: CORE_METRICS_STATSD_WRITEINTERVAL
+              value: {{ $.Values.global.metrics.statsd.writeInterval }}
+            - name: CORE_METRICS_STATSD_PREFIX
+              value: {{ .identity_name }}
+            {{- else }}
+              value: "disabled"
+            {{- end }}
             {{- if $.Values.additonalEnvironmentVars.peer }}
             {{- tpl (toYaml $.Values.additonalEnvironmentVars.peer) $ | nindent 12 }}
             {{- end }}

--- a/helm-charts/fabric-peer/templates/servicemonitor.yaml
+++ b/helm-charts/fabric-peer/templates/servicemonitor.yaml
@@ -1,0 +1,48 @@
+{{- if and (eq "prometheus" $.Values.global.metrics.provider) $.Values.global.metrics.serviceMonitor.enabled }}
+{{- range .Values.peers }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .name }}-{{ include "fabric-peer.name" $ }}
+  labels:
+    peer: {{ .identity_name }}
+    {{- include "fabric-peer.labels" $ | nindent 4 }}
+  {{- if $.Values.global.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml $.Values.global.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+  {{- end }}
+{{- if $.Values.global.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.global.metrics.serviceMonitor.namespace | quote }}
+{{- end }}
+spec:
+  endpoints:
+    - port: {{ $.Values.global.metrics.serviceMonitor.portName }}
+      interval: {{ $.Values.global.metrics.serviceMonitor.scrapeInterval }}
+    {{- if $.Values.global.metrics.serviceMonitor.honorLabels }}
+      honorLabels: true
+    {{- end }}
+    {{- if $.Values.global.metrics.serviceMonitor.relabelings }}
+      relabelings: {{ toYaml $.Values.global.metrics.serviceMonitor.relabelings | nindent 8 }}
+    {{- end }}
+    {{- if $.Values.global.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml $.Values.global.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
+  jobLabel: {{ .identity_name }}
+{{- if $.Values.global.metrics.serviceMonitor.namespaceSelector }}
+  namespaceSelector: {{ toYaml $.Values.global.metrics.serviceMonitor.namespaceSelector | nindent 4 }}
+{{- else }}
+  namespaceSelector:
+    matchNames:
+      - {{ $.Release.Namespace }}
+{{- end }}
+{{- if $.Values.global.metrics.serviceMonitor.targetLabels }}
+  targetLabels:
+  {{- range $.Values.global.metrics.serviceMonitor.targetLabels }}
+    - {{ $ }}
+  {{- end }}
+{{- end }}
+  selector:
+    matchLabels:
+      peer: {{ .identity_name }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Added the following:
- **Metrics support**: Users can now enable metrics provided by HLF Peers and Orderers. Both `prometheus` and `statsd` options are available. Users can also opt for the chart to create `servicemonitor` resources for prometheus metrics

- **Operations Service**: Exposed the operations service for both Peer and Orderer as a separate k8s service. Currently configurations are limited and TLS is not yet supported for operations service.