### PR TITLE
Add support to delete orgs from channel

### DIFF
--- a/examples/fabric-ops/initialpeerorg/configure-org-channel.yaml
+++ b/examples/fabric-ops/initialpeerorg/configure-org-channel.yaml
@@ -43,12 +43,14 @@ organizatons:
    identity_secret: org1AdminSamplePassword
    anchor_peer: peer0-org1.my-hlf-domain.com
    anchor_peer_port: 30000
+   status: active # Set to `disabled` to remove an org from the network.
  - name: org2
    ica_endpoint: ica-org2.my-hlf-domain.com:30000
    identity_name: admin
    identity_secret: org2AdminSamplePassword
    anchor_peer: peer0-org2.my-hlf-domain.com
    anchor_peer_port: 30000
+   status: active
 
 csr_names_cn: IN
 csr_names_st: Maharashtra

--- a/helm-charts/fabric-ca/Chart.yaml
+++ b/helm-charts/fabric-ca/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: fabric-ca
 description: A Helm chart for deploying Fabric CA Server in Kubernetes.
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.5.0"

--- a/helm-charts/fabric-ops/Chart.yaml
+++ b/helm-charts/fabric-ops/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: fabric-ops
 description: A Helm chart for performing various operations in Hyperledger fabric network.
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.5.0"

--- a/helm-charts/fabric-ops/README.md
+++ b/helm-charts/fabric-ops/README.md
@@ -13,7 +13,7 @@ A Helm chart for performing various operations in Hyperledger fabric network.
 - [x] [Chaincode installation](#how-to-install-chaincode-on-peers-)
 - [x] [Chaincode approval](#how-to-approve-chaincode-for-an-org-)
 - [x] [Chaincode commit](#how-to-commmit-chaincode-from-an-org-)
-- [x] [Orderer addition](#how-to-add-new-order-node-into-a-running-hyperpedger-fabric-network-)
+- [x] [Orderer addition](#how-to-add-new-orderer-node-into-a-running-hyperpedger-fabric-network-)
 - [x] [Orderer TLS cert renewal](#how-to-updaterenew-orderer-node-tls-certificates-in-a-running-hyperpedger-fabric-network-)
 
 #### The following parameters are common across all fabric-ops job.

--- a/helm-charts/fabric-ops/README.md
+++ b/helm-charts/fabric-ops/README.md
@@ -9,7 +9,7 @@ A Helm chart for performing various operations in Hyperledger fabric network.
 - [x] [Genesis block creation](#how-to-create-genesis-block--channel-transaction-tx-)
 - [x] [Channel creation](#how-to-create-new-channel-in-hyperpedger-fabric-)
 - [x] [Anchorpeer list update on channel](#how-to-update-anchorpeer-on-channel-)
-- [x] [Add/remove Orgs in channel](#how-to-add-a-new-org-to-channel-)
+- [x] [Add/remove Orgs in channel](#how-to-addremove-an-org-in-channel-)
 - [x] [Chaincode installation](#how-to-install-chaincode-on-peers-)
 - [x] [Chaincode approval](#how-to-approve-chaincode-for-an-org-)
 - [x] [Chaincode commit](#how-to-commmit-chaincode-from-an-org-)
@@ -299,7 +299,7 @@ peer_identities:
 | `admin_identity` | Any valid Admin user identity array in `ica_endpoint`. [Refer](#Admin-identity) | `[]` |
 
 
-## How to add new Order node into a running hyperpedger fabric network ?
+## How to add new Orderer node into a running hyperpedger fabric network ?
 
 | Parameter                | Description             | Default        |
 | ------------------------ | ----------------------- | -------------- |
@@ -313,7 +313,7 @@ peer_identities:
 | `additional_orderers` | List of additional oderers. Execute one at a time. [Refer](#New-orderer-for-order-addition) | `[]` |
 | `MspIdOverride` | To override `nameOverride` with a different MSPID | `""` |
 
-#### Admin identity for order operation;
+#### Admin identity for Orderer operation;
 
 ```bash
 admin_identity:

--- a/helm-charts/fabric-ops/README.md
+++ b/helm-charts/fabric-ops/README.md
@@ -9,12 +9,12 @@ A Helm chart for performing various operations in Hyperledger fabric network.
 - [x] [Genesis block creation](#how-to-create-genesis-block--channel-transaction-tx-)
 - [x] [Channel creation](#how-to-create-new-channel-in-hyperpedger-fabric-)
 - [x] [Anchorpeer list update on channel](#how-to-update-anchorpeer-on-channel-)
-- [x] [Adding Orgs to channel](#how-to-add-a-new-org-to-channel-)
+- [x] [Add/remove Orgs in channel](#how-to-add-a-new-org-to-channel-)
 - [x] [Chaincode installation](#how-to-install-chaincode-on-peers-)
 - [x] [Chaincode approval](#how-to-approve-chaincode-for-an-org-)
 - [x] [Chaincode commit](#how-to-commmit-chaincode-from-an-org-)
-- [x] [Order addition](#how-to-add-new-order-node-into-a-running-hyperpedger-fabric-network-)
-- [x] [Order TLS cert renewal](#how-to-updaterenew-orderer-node-tls-certificates-in-a-running-hyperpedger-fabric-network-)
+- [x] [Orderer addition](#how-to-add-new-order-node-into-a-running-hyperpedger-fabric-network-)
+- [x] [Orderer TLS cert renewal](#how-to-updaterenew-orderer-node-tls-certificates-in-a-running-hyperpedger-fabric-network-)
 
 #### The following parameters are common across all fabric-ops job.
 
@@ -198,7 +198,7 @@ anchor_peers:
      port: "30000"
 ```
 
-## How to add a new Org to channel ?
+## How to add/remove an Org in channel ?
 
 | Parameter                | Description             | Default        |
 | ------------------------ | ----------------------- | -------------- |
@@ -220,12 +220,14 @@ organizatons:
    identity_secret: org1AdminSamplePassword
    anchor_peer: peer0-org1.my-hlf-domain.com
    anchor_peer_port: 30000
+   status: active # `active` to add an org to the network.
  - name: org2
    ica_endpoint: ica-org2.my-hlf-domain.com:30000
    identity_name: admin
    identity_secret: org2AdminSamplePassword
    anchor_peer: peer0-org2.my-hlf-domain.com
    anchor_peer_port: 30000
+   status: disabled # `disabled` to remove an org from the network.
 ```
 
 ## How to install Chaincode on peers ?

--- a/helm-charts/fabric-ops/templates/cm-configure-org-channel.yaml
+++ b/helm-charts/fabric-ops/templates/cm-configure-org-channel.yaml
@@ -47,6 +47,8 @@ data:
               Port: {{ .anchor_peer_port }}
 {{- end }}
   fabric_configure_org_channel.sh: |
+      ORG_STATUS=$6
+      echo "============ Org status is set to $ORG_STATUS ============"
       source /scripts/fabric_enroll.sh
       fabric_public_key_fetch {{ $TlsCaEndpoint }} {{ $TlsCaTlsCertFile }}
       {{- range .Values.admin_identity }}
@@ -69,47 +71,94 @@ data:
       FABRIC_IDENTITY_SECRET=$4
       FABRIC_IDENTITY_MSP_DIR=$5
       FABRIC_TLS_CERT_FILE=/tmp/$ORG_NAME-cert.pem
-
-      echo "============ Updating channel for $ORG_NAME ============"
-      enroll \
-        $FABRIC_IDENTITY \
-        $FABRIC_IDENTITY_SECRET \
-        $FABRIC_IDENTITY_MSP_DIR \
-        $FABRIC_CA_URL \
-        null \
-        $FABRIC_TLS_CERT_FILE \
-        null \
-        {{ .Values.hlf_domain }} \
-        {{ .require_msp_enrollment | default "true" }} \
-        {{ .require_tls_enrollment | default "false" }}
       
-      echo "Rearranging Org specific msp directory"
-      mkdir $FABRIC_IDENTITY_MSP_DIR/$FABRIC_IDENTITY/msp/tlscacerts
-      cp -pr $FABRIC_IDENTITY_MSP_DIR/$FABRIC_IDENTITY/msp/cacerts/* $FABRIC_IDENTITY_MSP_DIR/$FABRIC_IDENTITY/msp/cacerts/ca-cert.pem      
-      cp {{ $TlsCaTlsCertFile }} $FABRIC_IDENTITY_MSP_DIR/$FABRIC_IDENTITY/msp/tlscacerts/ca.crt
+      if [ $ORG_STATUS = "active" ]; then
 
-      echo "============ Generating org material for $ORG_NAME ============"
-      configtxgen -configPath {{ $.Values.workdir }}/peer -printOrg $ORG_NAME > $ORG_NAME.json
-      echo "============ Fetching config block ============"
-      peer channel fetch config config_block.pb -o {{ .Values.orderer_endpoint }} -c {{ $ChannelName }} --tls --cafile $ORDERER_CA --connTimeout {{ .Values.connTimeout }}
-      echo "============ Converting the configuration to JSON ============"
-      configtxlator proto_decode --input config_block.pb --type common.Block | jq .data.data[0].payload.data.config > config.json
-      echo "============ Add the new Org $ORG_NAME crypto material ============"
-      jq -s '.[0] * {"channel_group":{"groups":{"Application":{"groups": {"'${ORG_NAME}'":.[1]}}}}}' config.json $ORG_NAME.json > modified_config.json
-      configtxlator proto_encode --input config.json --type common.Config --output config.pb
-      configtxlator proto_encode --input modified_config.json --type common.Config --output modified_config.pb
-      configtxlator compute_update --channel_id {{ $ChannelName }} --original config.pb --updated modified_config.pb --output org3_update.pb
-      configtxlator proto_decode --input org3_update.pb --type common.ConfigUpdate | jq . > org3_update.json
-      echo '{"payload":{"header":{"channel_header":{"channel_id":"{{ $ChannelName }}", "type":2}},"data":{"config_update":'$(cat org3_update.json)'}}}' | jq . > org3_update_in_envelope.json
-      configtxlator proto_encode --input org3_update_in_envelope.json --type common.Envelope --output org3_update_in_envelope.pb
-      echo "============ Signing the Channel Configuration Update ============"
-      peer channel signconfigtx -f org3_update_in_envelope.pb --connTimeout {{ .Values.connTimeout }}
-      echo "============ Updating Channel configuration ============"
-      peer channel update -f org3_update_in_envelope.pb -c {{ $ChannelName }} -o {{ .Values.orderer_endpoint }} --tls --cafile $ORDERER_CA --connTimeout {{ .Values.connTimeout }}
+        echo "========================================================================="
+        echo "============ Triggering org addition of $ORG_NAME to channel ============"
+        echo "========================================================================="
+        enroll \
+          $FABRIC_IDENTITY \
+          $FABRIC_IDENTITY_SECRET \
+          $FABRIC_IDENTITY_MSP_DIR \
+          $FABRIC_CA_URL \
+          null \
+          $FABRIC_TLS_CERT_FILE \
+          null \
+          {{ .Values.hlf_domain }} \
+          {{ .require_msp_enrollment | default "true" }} \
+          {{ .require_tls_enrollment | default "false" }}
+        
+        echo "============ Rearranging Org specific msp directory ============"
+        mkdir $FABRIC_IDENTITY_MSP_DIR/$FABRIC_IDENTITY/msp/tlscacerts
+        cp -pr $FABRIC_IDENTITY_MSP_DIR/$FABRIC_IDENTITY/msp/cacerts/* $FABRIC_IDENTITY_MSP_DIR/$FABRIC_IDENTITY/msp/cacerts/ca-cert.pem      
+        cp {{ $TlsCaTlsCertFile }} $FABRIC_IDENTITY_MSP_DIR/$FABRIC_IDENTITY/msp/tlscacerts/ca.crt
 
-      if [ $? -ne 0 ]; then
-        echo "============ [ERROR] One of the previous step returned an error, please debug it manually using cli pod and re-run this job if necessary. ============"
+        echo "============ Generating org material for $ORG_NAME ============"
+        configtxgen -configPath {{ $.Values.workdir }}/peer -printOrg $ORG_NAME > $ORG_NAME.json
+        
+        echo "============ Fetching config block ============"
+        peer channel fetch config config_block.pb -o {{ .Values.orderer_endpoint }} -c {{ $ChannelName }} --tls --cafile $ORDERER_CA --connTimeout {{ .Values.connTimeout }}
+        echo "============ Converting the configuration to JSON (jq) ============"
+        configtxlator proto_decode --input config_block.pb --type common.Block | jq .data.data[0].payload.data.config > config.json
+        echo "============ Adding the org information to JSON (jq) ============"
+        jq -s '.[0] * {"channel_group":{"groups":{"Application":{"groups": {"'${ORG_NAME}'":.[1]}}}}}' config.json $ORG_NAME.json > modified_config.json
+        echo "============ Converting config.json and modified_config.json files to protocol buffer ============"
+        configtxlator proto_encode --input config.json --type common.Config --output config.pb
+        configtxlator proto_encode --input modified_config.json --type common.Config --output modified_config.pb
+        echo "============ Compute the delta between original and modified pb files ============"
+        configtxlator compute_update --channel_id {{ $ChannelName }} --original config.pb --updated modified_config.pb --output org_update.pb
+        echo "============ Convert org_update.pb to JSON format (jq) ============"
+        configtxlator proto_decode --input org_update.pb --type common.ConfigUpdate | jq . > org_update.json
+        echo "============ Update header to Envelop JSON file. ============"
+        echo '{"payload":{"header":{"channel_header":{"channel_id":"{{ $ChannelName }}", "type":2}},"data":{"config_update":'$(cat org_update.json)'}}}' | jq . > org_update_in_envelope.json        
+        echo "============ Encode the Envelop JSON file to Protocol buffer. ============"
+        configtxlator proto_encode --input org_update_in_envelope.json --type common.Envelope --output org_update_in_envelope.pb        
+        echo "============ Signing the Channel Configuration Update ============"
+        peer channel signconfigtx -f org_update_in_envelope.pb --connTimeout {{ .Values.connTimeout }}        
+        echo "============ Updating Channel configuration by adding the org $ORG_NAME ============"
+        peer channel update -f org_update_in_envelope.pb -c {{ $ChannelName }} -o {{ .Values.orderer_endpoint }} --tls --cafile $ORDERER_CA --connTimeout {{ .Values.connTimeout }}
+
+        if [ $? -ne 0 ]; then
+          echo "============ [ERROR] One of the previous step returned an error, please debug it manually using cli pod and re-run this job if necessary. ============"
+        else
+          echo "============ [SUCCESS] All steps have been executed successfully. ============"
+        fi
+      
+      elif [ $ORG_STATUS = "disabled" ]; then
+
+        echo "=========================================================================="
+        echo "============ Triggering org removal of $ORG_NAME from channel ============"
+        echo "=========================================================================="
+        echo "============ Fetching config block ============"
+        peer channel fetch config config_block.pb -o {{ .Values.orderer_endpoint }} -c {{ $ChannelName }} --tls --cafile $ORDERER_CA --connTimeout {{ .Values.connTimeout }}
+        echo "============ Converting the configuration to JSON (jq) ============"
+        configtxlator proto_decode --input config_block.pb --type common.Block | jq .data.data[0].payload.data.config > config.json
+        echo "============ Removing the org information from JSON (jq) ============"
+        jq 'del(.channel_group.groups.Application.groups.'$ORG_NAME')' config.json > modified_config.json
+        echo "============ Converting config.json and modified_config.json files to protocol buffer ============"
+        configtxlator proto_encode --input config.json --type common.Config --output config.pb
+        configtxlator proto_encode --input modified_config.json --type common.Config --output modified_config.pb
+        echo "============ Compute the delta between original and modified pb files ============"
+        configtxlator compute_update --channel_id {{ $ChannelName }} --original config.pb --updated modified_config.pb --output config_update.pb
+        echo "============ Convert config_update.pb to JSON format ============"
+        configtxlator proto_decode --input config_update.pb --type common.ConfigUpdate --output config_update.json
+        echo "============ Update header to Envelop JSON file. ============"
+        echo '{"payload":{"header":{"channel_header":{"channel_id":"{{ $ChannelName }}", "type":2}},"data":{"config_update":'$(cat config_update.json)'}}}' | jq . > config_update_in_envelope.json
+        echo "============ Encode the Envelop JSON file to Protocol buffer. ============"
+        configtxlator proto_encode --input config_update_in_envelope.json --type common.Envelope --output config_update_in_envelope.pb
+        echo "============ Signing the Channel Configuration Update ============"
+        peer channel signconfigtx -f config_update_in_envelope.pb --connTimeout {{ .Values.connTimeout }}
+        echo "============ Updating Channel configuration by removing the org $ORG_NAME ============"
+        peer channel update -f config_update_in_envelope.pb -c {{ $ChannelName }} -o {{ .Values.orderer_endpoint }} --tls --cafile $ORDERER_CA --connTimeout {{ .Values.connTimeout }}
+        
+        if [ $? -ne 0 ]; then
+          echo "============ [ERROR] One of the previous step returned an error, please debug it manually using cli pod and re-run this job if necessary. ============"
+        else
+          echo "============ [SUCCESS] All steps have been executed successfully. ============"
+        fi
       else
-        echo "============ [SUCCESS] All steps have been executed successfully. ============"
+        echo "Wrong Org status value. It must be either active or disabled"
       fi
+        
   {{- end }}

--- a/helm-charts/fabric-ops/templates/cm-update-anchor-peer.yaml
+++ b/helm-charts/fabric-ops/templates/cm-update-anchor-peer.yaml
@@ -46,21 +46,20 @@ data:
       configtxlator proto_decode --input config_block.pb --type common.Block | jq .data.data[0].payload.data.config > config.json
       echo "============ Add the anchor peer configs ============"
       jq --argjson hostList "$(cat anchorpeer.json)" '.channel_group.groups.Application.groups.{{ $BankName }}.values += {"AnchorPeers":{"mod_policy": "Admins","value":{"anchor_peers": $hostList},"version": "0"}}' config.json > modified_config.json
-      echo "Executing configtxlator commands"
-      echo "============ Executing - configtxlator proto_encode --input config.json --type common.Config --output config.pb ============"
+      echo "============ Converting config.json and modified_config.json files to protocol buffer ============"
       configtxlator proto_encode --input config.json --type common.Config --output config.pb
-      echo "============ Executing - configtxlator proto_encode --input modified_config.json --type common.Config --output modified_config.pb ============"
       configtxlator proto_encode --input modified_config.json --type common.Config --output modified_config.pb
-      echo "============ Executing - configtxlator compute_update --channel_id {{ $ChannelName }} --original config.pb --updated modified_config.pb --output anchor_update.pb ============================"
+      echo "============ Compute the delta between original and modified pb files ============"
       configtxlator compute_update --channel_id {{ $ChannelName }} --original config.pb --updated modified_config.pb --output anchor_update.pb
-      echo "============ Executing - configtxlator proto_decode --input anchor_update.pb --type common.ConfigUpdate | jq . > anchor_update.json ============"
+      echo "============ Convert config_update.pb to JSON format ============"
       configtxlator proto_decode --input anchor_update.pb --type common.ConfigUpdate | jq . > anchor_update.json
+      echo "============ Update header to Envelop JSON file. ============"
       echo '{"payload":{"header":{"channel_header":{"channel_id":"{{ $ChannelName }}", "type":2}},"data":{"config_update":'$(cat anchor_update.json)'}}}' | jq . > anchor_update_in_envelope.json
-      echo "============ configtxlator proto_encode --input anchor_update_in_envelope.json --type common.Envelope --output anchor_update_in_envelope.pb ============"
+      echo "============ Encode the Envelop JSON file to Protocol buffer. ============"
       configtxlator proto_encode --input anchor_update_in_envelope.json --type common.Envelope --output anchor_update_in_envelope.pb
       echo "============ Signing the Channel Configuration ============"
       peer channel signconfigtx -f anchor_update_in_envelope.pb --connTimeout {{ .Values.connTimeout }}
-      echo "============ Running peer channel update ============"
+      echo "============ Updating Channel configuration with anchor peers list ============"
       peer channel update -f anchor_update_in_envelope.pb -c {{ $ChannelName }} -o {{ .Values.orderer_endpoint }} --tls --cafile $ORDERER_CA --connTimeout {{ .Values.connTimeout }}
 
       if [ $? -ne 0 ]; then

--- a/helm-charts/fabric-ops/templates/job-configure-org-channel.yaml
+++ b/helm-charts/fabric-ops/templates/job-configure-org-channel.yaml
@@ -15,7 +15,7 @@ SPDX-License-Identifier:  GPL-3.0
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "fabric-ops.fullname" $ }}-{{ .name }}
+  name: {{ include "fabric-ops.fullname" $ }}-{{ .name }}-{{ .status }}
   labels:
     {{- include "fabric-ops.labels" $ | nindent 4 }}
 spec:
@@ -46,7 +46,7 @@ spec:
           workingDir: {{ $.Values.workdir }}/peer
           command: ["/bin/sh","-c"]
           args:
-           - /scripts/fabric_configure_org_channel.sh {{ .name }} {{ .ica_endpoint }} {{ .identity_name }} {{ .identity_secret }} {{ .msp_dir | default "/crypto-config/peerOrganizations" }};
+           - /scripts/fabric_configure_org_channel.sh {{ .name }} {{ .ica_endpoint }} {{ .identity_name }} {{ .identity_secret }} {{ .msp_dir | default "/crypto-config/peerOrganizations" }} {{ .status }};
           tty: true
           env: 
             - name: FABRIC_LOGGING_SPEC

--- a/helm-charts/fabric-orderer/Chart.yaml
+++ b/helm-charts/fabric-orderer/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: fabric-orderer
 description: A Helm chart for deploying Fabric Orderers in Kubernetes.
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "2.4"

--- a/helm-charts/fabric-peer/Chart.yaml
+++ b/helm-charts/fabric-peer/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: fabric-peer
 description: A Helm chart for deploying Fabric Peers in Kubernetes.
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "2.4"

--- a/helm-charts/fabric-tools/Chart.yaml
+++ b/helm-charts/fabric-tools/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: fabric-tools
 description: A Helm chart for deploying Fabric cli tools in Kubernetes.
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.5.0"

--- a/helm-charts/filestore/Chart.yaml
+++ b/helm-charts/filestore/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: filestore
 description: A Helm chart for deploying an Nginx file sharing web server in Kubernetes.
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.16.0"


### PR DESCRIPTION
* Corrected typo in `.Values.organizatons` to `.Values.organizations`
* Introduced an additional field `.status` in the organizations array in `configure_org_channel` job to control the addition/removal of Org in channel. Preferred to run one org operations at a time. 

 ```
- name: org1
   ica_endpoint: ica-org1.my-hlf-domain.com:30000
   identity_name: admin
   identity_secret: org1AdminSamplePassword
   anchor_peer: peer0-org1.my-hlf-domain.com
   anchor_peer_port: 30000
   status: active # Set to `disabled` to remove an org from the network.
```