### PR TITLE
Adding multi channel support on channel creation job

### DIFF
--- a/examples/fabric-ops/initialpeerorg/channel-create.yaml
+++ b/examples/fabric-ops/initialpeerorg/channel-create.yaml
@@ -19,25 +19,34 @@ tlsca_endpoint: tls-ca.my-hlf-domain.com:30000
 orderer_endpoint: orderer0-orderer.my-hlf-domain.com:30000
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
 filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
-config_transaction_filename: channel.tx
-channel_block_filename: mychannel.block
-
 
 hlf_domain: my-hlf-domain.com
-hlf_channel: mychannel
 fabric_actions: 
  create_channel: true
- 
+
+app_channels:
+  - mychannel
+   
+admin_organizations:
+  - org_type: peerorg
+    org_name: initialpeerorg
+    ica_endpoint: ica-initialpeerorg.my-hlf-domain.com:30000
+    cert_path: /root/initialpeerorg.pem
+    admin_identity: admin
+    admin_secret: initialpeerorgAdminSamplePassword
+    require_msp_enrollment: true
+    require_tls_enrollment: false
+    anchor_peers:
+    - host: peer0-initialpeerorg.my-hlf-domain.com
+      port: "30000"
+
 csr_names_cn: IN
 csr_names_st: Maharashtra
 csr_names_l: Mumbai
 csr_names_o: Your Company Name
 
-admin_identity:
-  - identity_name: admin
-    identity_secret: initialpeerorgAdminSamplePassword
-    require_msp_enrollment: true
-    require_tls_enrollment: false
+configTxProfileType: ConsortiumOrgProfile
+core_peer_mspconfigpath_override: "" # Required only if admin_identity name is not "admin". You will have to add the complete path to the msp directory in this case.
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/examples/fabric-ops/orderer/orderer-cryptogen.yaml
+++ b/examples/fabric-ops/orderer/orderer-cryptogen.yaml
@@ -18,7 +18,7 @@ imagePullSecrets: []
 
 ## These organizations are the list of initial organizations required to generate the genesis.block file. 
 
-organizations:
+admin_organizations:
   - org_type: orderer
     org_name: orderer
     ica_endpoint: ica-orderer.my-hlf-domain.com:30000
@@ -45,16 +45,12 @@ organizations:
     - host: peer0-initialpeerorg.my-hlf-domain.com
       port: "30000"
 
-channel_artifact_dir: /scripts/channel-artifacts
-base_dir: /scripts/crypto-config
 hlf_domain: my-hlf-domain.com
 orderer_system_channel: "orderer-sys-channel"
-hlf_channel: "mychannel"
 block_file: genesis.block
-config_transaction_filename: channel.tx
+configTxProfileType: OrdererNodeEtcdRaftProfile
 
 tlsca_endpoint: tls-ca.my-hlf-domain.com:30000
-
 filestore_endpoint: http://filestore.my-hlf-domain.com:30001
 filestore_ssl: false # Make it `true` if `filestore_endpoint` is over https.
 

--- a/helm-charts/fabric-ops/templates/cm-common-functions.yaml
+++ b/helm-charts/fabric-ops/templates/cm-common-functions.yaml
@@ -175,3 +175,16 @@ data:
         fi
 
       }
+
+      function check_exit_status() {
+
+          local exit_status=$1
+
+          if [ $exit_status -eq 0 ]; then
+            echo "============ [SUCCESS] ============"
+            break;
+          else
+            echo "============ [ERROR] One of the previous step returned an error, please debug it manually using cli pod and re-run this job if necessary. ============"
+            exit
+          fi
+      }

--- a/helm-charts/fabric-ops/templates/cm-configtx.yaml
+++ b/helm-charts/fabric-ops/templates/cm-configtx.yaml
@@ -3,10 +3,10 @@ Copyright National Payments Corporation of India. All Rights Reserved.
 SPDX-License-Identifier:  GPL-3.0
 */}}
 
-{{- if .Values.fabric_actions.cryptogen }}
+{{- if or (.Values.fabric_actions.cryptogen) (.Values.fabric_actions.create_channel) }}
 
 {{- $HlfDomain      := .Values.hlf_domain }}
-{{- $BaseDir        := .Values.base_dir }}
+{{- $BaseDir        := .Values.workdir }}
 {{- $OrdererOrgName := .Values.orderer_org_name }}
 {{- $PeerOrgName    := .Values.peer_org_name }}
 
@@ -20,7 +20,7 @@ metadata:
 data:
  configtx.yaml: |
   Organizations:
-  {{- range .Values.organizations }}
+  {{- range .Values.admin_organizations }}
     - &{{ .org_name }}
         # DefaultOrg defines the organization which is used in the sampleconfig
         # of the fabric.git development environment
@@ -246,25 +246,27 @@ data:
     #
     ################################################################################
   Profiles:
-
-  {{- range .Values.organizations }}
-    {{- if eq "peerorg" .org_type }}
-    TwoOrgsChannel:
+  {{- if eq "ConsortiumOrgProfile" .Values.configTxProfileType }}
+    ConsortiumOrgProfile:
         Consortium: SampleConsortium
         <<: *ChannelDefaults
         Application:
             <<: *ApplicationDefaults
             Organizations:
+              {{- range .Values.admin_organizations }}
+              {{- if eq "peerorg" .org_type }}
                 - *{{ .org_name }}
+              {{- end }}
+              {{- end }}
             Capabilities:
                 <<: *ApplicationCapabilities
-    {{- end }}
   {{- end }}
-    SampleMultiNodeEtcdRaft:
+  {{- if eq "OrdererNodeEtcdRaftProfile" .Values.configTxProfileType }}
+    OrdererNodeEtcdRaftProfile:
         <<: *ChannelDefaults
         Capabilities:
             <<: *ChannelCapabilities
-    {{- range .Values.organizations }}
+    {{- range .Values.admin_organizations }}
     {{ $Org_name := .org_name }}
       {{- if eq "orderer" .org_type }}
         Orderer:
@@ -293,13 +295,13 @@ data:
             - <<: *{{ $Org_name }}
       {{- end }}
     {{- end }}
-    {{- range .Values.organizations }}
-        {{- if eq "peerorg" .org_type }}    
         Consortiums:
-            SampleConsortium:
-                Organizations:
-                - *{{ .org_name }}
-        {{- end }}
-    {{- end }}
-
+          SampleConsortium:
+            Organizations:
+            {{- range .Values.admin_organizations }}
+            {{- if eq "peerorg" .org_type }} 
+             - *{{ .org_name }}
+            {{- end }}
+            {{- end }}
+  {{- end }}
 {{- end }}

--- a/helm-charts/fabric-ops/templates/cm-create-channel.yaml
+++ b/helm-charts/fabric-ops/templates/cm-create-channel.yaml
@@ -3,14 +3,15 @@ Copyright National Payments Corporation of India. All Rights Reserved.
 SPDX-License-Identifier:  GPL-3.0
 */}}
 
-{{- $Project           := .Values.project }}
-{{- $HlfDomain         := .Values.hlf_domain }}
-{{- $IcaEndPoint       := .Values.ica_endpoint }}
-{{- $TlsCaEndpoint     := .Values.tlsca_endpoint }}
-{{- $IcaTlsCertFile    := .Values.ica_tls_certfile | default "/tmp/ca-cert.pem" }}
-{{- $TlsCaTlsCertFile  := .Values.tlsca_tls_certfile | default "/tmp/tlsca-cert.pem" }}
-{{- $ChannelName       := .Values.hlf_channel }}
-{{- $Msp_base_dir      := printf "%s%s" .Values.workdir "/peer/crypto/users" }}
+{{- $Project            := .Values.project }}
+{{- $HlfDomain          := .Values.hlf_domain }}
+{{- $IcaEndPoint        := .Values.ica_endpoint }}
+{{- $TlsCaEndpoint      := .Values.tlsca_endpoint }}
+{{- $IcaTlsCertFile     := .Values.ica_tls_certfile | default "/tmp/ca-cert.pem" }}
+{{- $TlsCaTlsCertFile   := .Values.tlsca_tls_certfile | default "/tmp/tlsca-cert.pem" }}
+{{- $ChannelName        := .Values.hlf_channel }}
+{{- $MspBaseDir         := .Values.workdir }}
+{{- $ChannelArtifactDir := .Values.channel_artifact_dir | default "/scripts" }}
 
 {{- if .Values.fabric_actions.create_channel | default false }}
 
@@ -22,13 +23,14 @@ metadata:
     {{- include "fabric-ops.labels" $ | nindent 4 }}
 data:
   fabric_create_channel.sh: |
+      channel_name=$1
       source /scripts/fabric_enroll.sh
       fabric_public_key_fetch {{ $TlsCaEndpoint }} {{ $TlsCaTlsCertFile }}
-      {{- range .Values.admin_identity }}
+      {{- range .Values.admin_organizations }}
       enroll \
-        {{ .identity_name }} \
-        {{ .identity_secret }} \
-        {{ .msp_base_dir | default $Msp_base_dir }} \
+        {{ .admin_identity }} \
+        {{ .admin_secret }} \
+        {{ .msp_base_dir | default (printf "%s%s%s" $MspBaseDir "/" .org_name) }} \
         {{ .ica_endpoint | default $IcaEndPoint }} \
         {{ .tlsca_endpoint | default $TlsCaEndpoint }} \
         {{ .ica_tls_certfile | default $IcaTlsCertFile }} \
@@ -36,19 +38,32 @@ data:
         {{ .hlf_domain | default $.Values.hlf_domain }} \
         {{ .require_msp_enrollment }} \
         {{ .require_tls_enrollment }}
-    {{- end }}
+      {{- end }}
 
-      get_file {{ $.Values.workdir }}/peer/{{ .Values.config_transaction_filename }} {{ .Values.filestore_endpoint }}/{{ $Project }}/{{ .Values.config_transaction_filename }}
-      echo "Printing the downloaded file {{ $.Values.workdir }}/peer/{{ .Values.config_transaction_filename }}"
-      cat {{ $.Values.workdir }}/peer/{{ .Values.config_transaction_filename }}
+      echo "--------------------------------------------------------------------"
+      echo "Generating Configuration transaction file ${channel_name}.tx at {{ $ChannelArtifactDir }}/${channel_name}.tx";
+      echo "--------------------------------------------------------------------"
+      configtxgen -profile ConsortiumOrgProfile -outputCreateChannelTx {{ $ChannelArtifactDir }}/${channel_name}.tx -channelID ${channel_name} -configPath {{ $.Values.workdir }}/peer/
+      check_exit_status $?
+      sleep 5
+      echo "--------------------------------"
+      echo "Printing generated ${channel_name}.tx"
+      echo "--------------------------------"
+      configtxgen -inspectChannelCreateTx {{ $ChannelArtifactDir }}/${channel_name}.tx || jq .
+      echo "\n"
+      echo "--------------------------------------------------------------------"
+      CHANNELTX_SHA=$(sha256sum {{ $ChannelArtifactDir }}/${channel_name}.tx)
+      echo "SHA256 value = $CHANNELTX_SHA"
+      
+      echo "============ Creating channel ${channel_name} ============"
+      peer channel create -o {{ $.Values.orderer_endpoint }} -c ${channel_name} -f {{ $ChannelArtifactDir }}/${channel_name}.tx --outputBlock {{ $ChannelArtifactDir }}/${channel_name}.block --tls true --cafile $ORDERER_CA --connTimeout {{ $.Values.connTimeout }}
+      check_exit_status $?
 
-      echo "============ Creating channel ============"
-      peer channel create -o {{ .Values.orderer_endpoint }} -c {{ $ChannelName }} -f {{ $.Values.workdir }}/peer/{{ .Values.config_transaction_filename }} --tls true --cafile $ORDERER_CA --connTimeout {{ .Values.connTimeout }}
-      echo "============ Uploading {{ .Values.channel_block_filename }} to Filestore at {{ .Values.filestore_endpoint }} ============"
-      upload_file {{ .Values.channel_block_filename }} {{ .Values.filestore_endpoint }}/{{ $Project }}/
-      if [ $? -ne 0 ]; then
-        echo "============ [ERROR] One of the previous step returned an error, please debug it manually using cli pod and re-run this job if necessary. ============"
-      else
-        echo "============ [SUCCESS] All steps have been executed successfully. ============"
-      fi
-  {{- end }}
+      echo "Printing generated ${channel_name}.tx"
+      configtxgen -inspectBlock {{ $ChannelArtifactDir }}/${channel_name}.block | jq .
+      echo "============ Uploading {{ $ChannelArtifactDir }}/${channel_name}.block to Filestore at {{ $.Values.filestore_endpoint }} ============"
+      upload_file {{ $ChannelArtifactDir }}/${channel_name}.block {{ $.Values.filestore_endpoint }}/{{ $Project }}/
+      echo "============ Uploading {{ $ChannelArtifactDir }}/${channel_name}.tx to Filestore at {{ $.Values.filestore_endpoint }} ============"
+      upload_file {{ $ChannelArtifactDir }}/${channel_name}.tx {{ $.Values.filestore_endpoint }}/{{ $Project }}/ 
+
+ {{- end }}

--- a/helm-charts/fabric-ops/templates/cm-cryptogen.yaml
+++ b/helm-charts/fabric-ops/templates/cm-cryptogen.yaml
@@ -5,12 +5,12 @@ SPDX-License-Identifier:  GPL-3.0
 
 {{- if .Values.fabric_actions.cryptogen }}
 
-{{- $BaseDir           := .Values.base_dir }}
-{{- $Project           := .Values.project }}
-{{- $TlsCaEndPoint     := .Values.tlsca_endpoint }}
-{{- $TlsCaTlsCertFile  := .Values.tlsca_tls_certfile | default "/tmp/tlsca-cert.pem" }}
-{{- $HlfDomain         := .Values.hlf_domain }}
-{{- $ChannelName       := .Values.hlf_channel }}
+{{- $BaseDir            := .Values.workdir }}
+{{- $Project            := .Values.project }}
+{{- $TlsCaEndPoint      := .Values.tlsca_endpoint }}
+{{- $TlsCaTlsCertFile   := .Values.tlsca_tls_certfile | default "/tmp/tlsca-cert.pem" }}
+{{- $HlfDomain          := .Values.hlf_domain }}
+{{- $ChannelArtifactDir := .Values.channel_artifact_dir | default "/scripts" }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -24,14 +24,15 @@ data:
     source /scripts/fabric_enroll.sh 
     fabric_public_key_fetch {{ $TlsCaEndPoint }} {{ $TlsCaTlsCertFile }}
      
-    {{- range .Values.organizations }}
+    {{- range .Values.admin_organizations }}
       {{- if eq "orderer" .org_type }}
         {{ $org_name     := .org_name }}
         {{ $ica_endpoint := .ica_endpoint }}
         {{ $cert_path    := .cert_path }}
         {{- range .orderer_identities }}
-          
-          {{- $msp_dir := printf "%s/%s" $BaseDir $org_name }}
+
+        echo "============ Starting Orderer identity enrollments. ============"          
+        {{- $msp_dir := printf "%s/%s" $BaseDir $org_name }}
         enroll \
           {{ .identity_name }} \
           {{ .identity_secret }} \
@@ -56,7 +57,7 @@ data:
 
      echo "============ Starting Org admin enrollments. ============"
 
-     {{- range .Values.organizations }}
+     {{- range .Values.admin_organizations }}
      {{- $msp_dir := printf "%s/%s" $BaseDir .org_name }}
     
      enroll \
@@ -76,32 +77,25 @@ data:
      {{- end }}
 
      echo "--------------------------------------------------------------------"
-     echo "Generating Genesis block file {{ .Values.block_file }} at {{ .Values.channel_artifact_dir }}/{{ .Values.block_file }}";
+     echo "Generating Genesis block file {{ .Values.block_file }} at {{ $ChannelArtifactDir }}/{{ .Values.block_file }}";
      echo "--------------------------------------------------------------------"
-     configtxgen -profile SampleMultiNodeEtcdRaft -channelID {{ .Values.orderer_system_channel }} -outputBlock {{ .Values.channel_artifact_dir }}/{{ .Values.block_file }};
+     configtxgen -profile OrdererNodeEtcdRaftProfile -channelID {{ .Values.orderer_system_channel }} -outputBlock {{ $ChannelArtifactDir }}/{{ .Values.block_file }};
+     
+     if [ $? -ne 0 ]; then
+        echo "============ [ERROR] Genesis block creation failed with an error, please debug it manually using cli pod and re-run this job if necessary. ============"
+        exit
+      else
+        echo "============ [SUCCESS] Genesis block creation has been executed successfully. ============"
+      fi
+
      sleep 5;
      echo "--------------------------------"
      echo "Printing generated {{ .Values.block_file }}"     
      echo "--------------------------------"
-     cat {{ .Values.channel_artifact_dir }}/{{ .Values.block_file }}
+     configtxgen -inspectBlock {{ $ChannelArtifactDir }}/{{ .Values.block_file }} | jq .
      echo "--------------------------------"
-     GENESIS_SHA=$(sha256sum {{ .Values.channel_artifact_dir }}/{{ .Values.block_file }})
+     GENESIS_SHA=$(sha256sum {{ $ChannelArtifactDir }}/{{ .Values.block_file }})
      echo "SHA256 value = $GENESIS_SHA"
      echo "--------------------------------"
-
-     echo "--------------------------------------------------------------------"
-     echo "Generating Configuration transaction file {{ .Values.config_transaction_filename }} at {{ .Values.channel_artifact_dir }}/{{ .Values.config_transaction_filename }}";
-     echo "--------------------------------------------------------------------"
-     configtxgen -profile TwoOrgsChannel -outputCreateChannelTx {{ .Values.channel_artifact_dir }}/{{ .Values.config_transaction_filename }} -channelID {{ $ChannelName }};
-     sleep 5
-     echo "--------------------------------"
-     echo "Printing generated {{ .Values.config_transaction_filename }}"
-     echo "--------------------------------"
-     cat {{ .Values.channel_artifact_dir }}/{{ .Values.config_transaction_filename }}
-     echo "\n"
-     echo "--------------------------------------------------------------------"
-     CHANNELTX_SHA=$(sha256sum {{ .Values.channel_artifact_dir }}/{{ .Values.config_transaction_filename }})
-     echo "SHA256 value = $CHANNELTX_SHA"
-     upload_file {{ .Values.channel_artifact_dir }}/{{ .Values.block_file }} {{ .Values.filestore_endpoint }}/{{ $Project }}/
-     upload_file {{ .Values.channel_artifact_dir }}/{{ .Values.config_transaction_filename }} {{ .Values.filestore_endpoint }}/{{ $Project }}/ 
+     upload_file {{ $ChannelArtifactDir }}/{{ .Values.block_file }} {{ .Values.filestore_endpoint }}/{{ $Project }}/
 {{- end }}

--- a/helm-charts/fabric-ops/templates/job-create-channel.yaml
+++ b/helm-charts/fabric-ops/templates/job-create-channel.yaml
@@ -5,17 +5,15 @@ SPDX-License-Identifier:  GPL-3.0
 
 {{- if .Values.fabric_actions.create_channel | default false }}
 
-{{ $BankName          := .Values.nameOverride }}
-{{ $HlfDomain         := .Values.hlf_domain }}
-{{ $ChannelName       := .Values.channel_name }}
-{{ $Msp_base_dir      := printf "%s%s" .Values.workdir "/peer/crypto/users/" }}
+{{ $BankName               := .Values.nameOverride }}
+{{ $CorePeerMspConfigPath  := printf "%s%s%s%s%s" .Values.workdir "/" $BankName "/admin" "/msp" }}
 
-{{- range .Values.admin_identity }}
+{{- range .Values.app_channels }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "fabric-ops.fullname" $ }}
+  name: {{ $.Release.Name }}-{{ . }}
   labels:
     {{- include "fabric-ops.labels" $ | nindent 4 }}
 spec:
@@ -46,7 +44,7 @@ spec:
           workingDir: {{ $.Values.workdir }}/peer
           command: ["/bin/sh","-c"]
           args:
-           - /scripts/fabric_create_channel.sh;
+           - /scripts/fabric_create_channel.sh {{ . }};
           tty: true
           env: 
             - name: FABRIC_LOGGING_SPEC
@@ -54,7 +52,7 @@ spec:
             - name: CORE_PEER_LOCALMSPID
               value: {{ $BankName }}
             - name: CORE_PEER_MSPCONFIGPATH
-              value: {{ $.Values.core_peer_mspconfigpath_override | default (printf "%s%s%s" $Msp_base_dir .identity_name "/msp") }}
+              value: {{ $.Values.core_peer_mspconfigpath_override | default $CorePeerMspConfigPath }}
             - name: CORE_PEER_TLS_ENABLED
               value: "true"
             - name: GOPATH
@@ -71,12 +69,19 @@ spec:
             - name: scripts
               subPath: fabric_create_channel.sh
               mountPath: /scripts/fabric_create_channel.sh
+            - name: configtx
+              subPath: configtx.yaml
+              mountPath: {{ $.Values.workdir }}/peer/configtx.yaml
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
       volumes:
         - name: scripts
           configMap:
             name: {{ include "fabric-ops.fullname" $ }}
+            defaultMode: 0777
+        - name: configtx
+          configMap:
+            name: {{ include "fabric-ops.fullname" $ }}-configtx
             defaultMode: 0777
         - name: fabric-ops
           configMap:


### PR DESCRIPTION
- Added multi channel support on channel creation job.
- Removed `config_transaction_filename` & `channel_block_filename` from channel creation job and it will be calculated by the script based on the channel name. Eg; if channel name is `yourchannel`, then chart will render `yourchannel.tx` & `yourchannel.block` for the txn and block file.
- Changed `hlf_channel` to `app_channels` in channel creation job. Now it supports an array of channel names to be created. 
- Changed `admin_identity` to `admin_organizations` for channel creation job. This is to re-use the existing configtx.yaml used by the cryptogen job. 
- Aded new value `configTxProfileType` on cryptogen and channel creation job. For app channel creation the value should be `ConsortiumOrgProfile` & for orderer system channel it should be `OrdererNodeEtcdRaftProfile`
- Changed `.Values.organizations `to `.Values.admin_organizations` in cryptogen job. This is to re-use the existing configtx.yaml.
- Removed the following from cryptogen job. `channel_artifact_dir, base_dir, hlf_channel & config_transaction_filename`
- Added common function to check exit status. 